### PR TITLE
Fix acceptAlertButtonSelector matching 'Don't Allow' instead of 'Allow'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `runFlow: when` conditions with variable expressions (e.g., `${output.element.id}`) were never expanded, causing conditions to always evaluate as false and silently skip conditional blocks
+- iOS real device: `acceptAlertButtonSelector` matched "Don't Allow" instead of "Allow" — `CONTAINS[c] 'Allow'` matched both buttons, causing WDA to reject permission dialogs. Changed to `BEGINSWITH[c] 'Allow'` with `OK` fallback for older iOS versions
 
 ## [1.0.7] - 2026-02-20
 

--- a/pkg/driver/wda/commands.go
+++ b/pkg/driver/wda/commands.go
@@ -751,7 +751,7 @@ func (d *Driver) launchApp(step *flow.LaunchAppStep) *core.CommandResult {
 			"waitForIdleTimeout":      0,
 		}
 		if d.alertAction == "accept" {
-			sessionSettings["acceptAlertButtonSelector"] = "**/XCUIElementTypeButton[`label CONTAINS[c] 'Allow'`]"
+			sessionSettings["acceptAlertButtonSelector"] = "**/XCUIElementTypeButton[`label BEGINSWITH[c] 'Allow' OR label ==[c] 'OK'`]"
 		} else if d.alertAction == "dismiss" {
 			sessionSettings["dismissAlertButtonSelector"] = "**/XCUIElementTypeButton[`label CONTAINS[c] 'Don't Allow' OR label CONTAINS[c] 'Dont Allow'`]"
 		}


### PR DESCRIPTION
## Summary

Fix the `acceptAlertButtonSelector` WDA setting that incorrectly matched "Don't Allow" buttons on iOS permission dialogs, causing permissions to be rejected instead of accepted on real devices.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

- Changed `acceptAlertButtonSelector` from `CONTAINS[c] 'Allow'` to `BEGINSWITH[c] 'Allow' OR label ==[c] 'OK'`
- `CONTAINS 'Allow'` matched both "Allow" and "Don't Allow" buttons — WDA tapped the first match in the hierarchy, which was "Don't Allow"
- `BEGINSWITH 'Allow'` correctly matches only "Allow" and "Allow While Using App"
- Added `==[c] 'OK'` fallback for older iOS dialogs that use "OK" instead of "Allow"

## Related Issues

N/A

## Testing

- [x] Tests pass locally (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Added tests for new functionality
- [x] Tested manually with sample flows

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [ ] Added/updated documentation as needed
- [x] No breaking changes (or documented if breaking)
- [x] CHANGELOG.md updated (for notable changes)

## Additional Notes

Reproduced on a real iOS device running an app that requests microphone permission. The `setPermissions` step with `microphone: allow` configured WDA's auto-alert handler, but the `CONTAINS[c] 'Allow'` predicate in the `acceptAlertButtonSelector` matched "Don't Allow" first, rejecting the permission dialog.

<img width="338" height="250" alt="Screenshot 2026-02-27 at 3 28 08 PM" src="https://github.com/user-attachments/assets/70207fe1-9afa-4288-ae09-727497376f34" />
