### PR TITLE
Add runFlow timeout with context propagation

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"net"
 	"os"
 	"strconv"
@@ -30,6 +31,7 @@ func (m *mockDriver) GetState() *core.StateSnapshot         { return nil }
 func (m *mockDriver) GetPlatformInfo() *core.PlatformInfo   { return m.platformInfo }
 func (m *mockDriver) SetFindTimeout(int)                    {}
 func (m *mockDriver) SetWaitForIdleTimeout(int) error       { return nil }
+func (m *mockDriver) SetContext(context.Context)             {}
 
 func TestResolveOutputDir_Default(t *testing.T) {
 	dir, err := resolveOutputDir("", false)

--- a/pkg/core/driver.go
+++ b/pkg/core/driver.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"time"
 
 	"github.com/devicelab-dev/maestro-runner/pkg/flow"
@@ -33,6 +34,11 @@ type Driver interface {
 	// 0 = disabled, >0 = wait up to N ms for device to be idle.
 	// This is used by waitForIdleTimeout in flow config.
 	SetWaitForIdleTimeout(ms int) error
+
+	// SetContext sets the parent context for element-finding operations.
+	// When set, driver polling loops use this as the parent context so that
+	// external cancellation (e.g. runFlow timeout) can interrupt them.
+	SetContext(ctx context.Context)
 }
 
 // CommandResult represents the outcome of executing a single command

--- a/pkg/driver/appium/commands.go
+++ b/pkg/driver/appium/commands.go
@@ -249,6 +249,10 @@ func (d *Driver) scrollUntilVisible(step *flow.ScrollUntilVisibleStep) *core.Com
 	}
 
 	for i := 0; i < maxScrolls && time.Now().Before(deadline); i++ {
+		if err := d.parentContext().Err(); err != nil {
+			return errorResult(fmt.Errorf("scroll cancelled: %w", err), "")
+		}
+
 		// Check if element is visible
 		info, err := d.findElement(step.Element, 1*time.Second)
 		if err == nil && info != nil {
@@ -723,7 +727,7 @@ func (d *Driver) waitUntil(step *flow.WaitUntilStep) *core.CommandResult {
 		timeout = time.Duration(step.TimeoutMs) * time.Millisecond
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(d.parentContext(), timeout)
 	defer cancel()
 
 	var selector *flow.Selector

--- a/pkg/driver/appium/driver.go
+++ b/pkg/driver/appium/driver.go
@@ -21,6 +21,7 @@ type Driver struct {
 	capabilities              map[string]interface{} // stored for session recreation (deep copy of original)
 	platform                  string                 // detected from page source or capabilities
 	appID                     string                 // current app ID
+	ctx                       context.Context        // parent context for element-finding operations (nil = context.Background())
 	findTimeout               time.Duration          // configurable timeout for finding elements
 	currentWaitForIdleTimeout int                    // track current value to skip redundant calls
 	waitForIdleTimeoutSet     bool                   // whether waitForIdleTimeout has been set
@@ -218,6 +219,19 @@ func (d *Driver) GetPlatformInfo() *core.PlatformInfo {
 	}
 }
 
+// SetContext sets the parent context for element-finding operations.
+func (d *Driver) SetContext(ctx context.Context) {
+	d.ctx = ctx
+}
+
+// parentContext returns the parent context for element-finding operations.
+func (d *Driver) parentContext() context.Context {
+	if d.ctx != nil {
+		return d.ctx
+	}
+	return context.Background()
+}
+
 // SetFindTimeout implements core.Driver.
 // Sets the default timeout (in ms) for finding elements.
 func (d *Driver) SetFindTimeout(ms int) {
@@ -275,6 +289,10 @@ func (d *Driver) findElement(sel flow.Selector, timeout time.Duration) (*core.El
 	deadline := time.Now().Add(timeout)
 
 	for {
+		if err := d.parentContext().Err(); err != nil {
+			return nil, fmt.Errorf("element '%s' not found: %w", sel.Describe(), err)
+		}
+
 		info, err := d.findElementDirect(sel)
 		if err == nil && info != nil {
 			return info, nil
@@ -444,6 +462,10 @@ func (d *Driver) findElementByPageSource(sel flow.Selector) (*core.ElementInfo, 
 func (d *Driver) findElementByPageSourceWithPolling(sel flow.Selector, timeout time.Duration) (*core.ElementInfo, error) {
 	deadline := time.Now().Add(timeout)
 	for {
+		if err := d.parentContext().Err(); err != nil {
+			return nil, fmt.Errorf("element '%s' not found: %w", sel.Describe(), err)
+		}
+
 		info, err := d.findElementByPageSource(sel)
 		if err == nil {
 			return info, nil
@@ -480,6 +502,10 @@ func (d *Driver) findElementForTap(sel flow.Selector, timeout time.Duration) (*c
 	deadline := time.Now().Add(timeout)
 
 	for {
+		if err := d.parentContext().Err(); err != nil {
+			return nil, fmt.Errorf("element '%s' not found: %w", sel.Describe(), err)
+		}
+
 		var info *core.ElementInfo
 		var err error
 
@@ -571,7 +597,7 @@ func (d *Driver) findElementForTapIOS(sel flow.Selector) (*core.ElementInfo, err
 // findElementRelative handles relative selectors (below, above, etc.)
 // Deprecated: Use findElementRelativeWithContext for new code.
 func (d *Driver) findElementRelative(sel flow.Selector, timeout time.Duration) (*core.ElementInfo, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(d.parentContext(), timeout)
 	defer cancel()
 	return d.findElementRelativeWithContext(ctx, sel)
 }

--- a/pkg/driver/devicelab/commands.go
+++ b/pkg/driver/devicelab/commands.go
@@ -39,7 +39,7 @@ func (d *Driver) tapOn(step *flow.TapOnStep) *core.CommandResult {
 			return errorResult(err, fmt.Sprintf("Failed to build selectors: %v", err))
 		}
 		timeout := d.calculateTimeout(step.IsOptional(), step.TimeoutMs)
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		ctx, cancel := context.WithTimeout(d.parentContext(), timeout)
 		defer cancel()
 
 		var lastErr error
@@ -1376,7 +1376,7 @@ func (d *Driver) waitUntil(step *flow.WaitUntilStep) *core.CommandResult {
 		timeout = time.Duration(step.TimeoutMs) * time.Millisecond
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(d.parentContext(), timeout)
 	defer cancel()
 
 	var selector *flow.Selector

--- a/pkg/driver/devicelab/driver.go
+++ b/pkg/driver/devicelab/driver.go
@@ -73,6 +73,9 @@ type Driver struct {
 	info   *core.PlatformInfo
 	device ShellExecutor // for ADB commands (fallback)
 
+	// Parent context for element-finding operations (nil = context.Background())
+	ctx context.Context
+
 	// Timeouts (0 = use defaults)
 	findTimeout         int // ms, for required elements
 	optionalFindTimeout int // ms, for optional elements
@@ -118,6 +121,20 @@ func (d *Driver) screenSize() (int, int, error) {
 		return d.info.ScreenWidth, d.info.ScreenHeight, nil
 	}
 	return 0, 0, fmt.Errorf("screen dimensions not available")
+}
+
+// SetContext sets the parent context for element-finding operations.
+func (d *Driver) SetContext(ctx context.Context) {
+	d.ctx = ctx
+}
+
+// parentContext returns the parent context for element-finding operations.
+// Returns context.Background() if no context was set.
+func (d *Driver) parentContext() context.Context {
+	if d.ctx != nil {
+		return d.ctx
+	}
+	return context.Background()
 }
 
 // SetFindTimeout sets the timeout for finding required elements.
@@ -315,7 +332,7 @@ func (d *Driver) findElementForTap(sel flow.Selector, optional bool, stepTimeout
 	// For relative selectors (below, above, etc.), use page source which handles them correctly
 	if sel.HasRelativeSelector() {
 		timeout := d.calculateTimeout(optional, stepTimeoutMs)
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		ctx, cancel := context.WithTimeout(d.parentContext(), timeout)
 		defer cancel()
 		return d.findElementRelativeWithContext(ctx, sel)
 	}
@@ -334,7 +351,7 @@ func (d *Driver) findElementForTap(sel flow.Selector, optional bool, stepTimeout
 	// Non-clickable strategies first, then clickable fallback
 	if sel.Text != "" {
 		timeout := d.calculateTimeout(optional, stepTimeoutMs)
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		ctx, cancel := context.WithTimeout(d.parentContext(), timeout)
 		defer cancel()
 		return d.findElementDirectWithContext(ctx, sel)
 	}
@@ -429,7 +446,7 @@ func buildClickableOnlyStrategies(sel flow.Selector) ([]LocatorStrategy, error) 
 // findElementWithOptions is the internal implementation with clickable preference option.
 func (d *Driver) findElementWithOptions(sel flow.Selector, optional bool, stepTimeoutMs int, preferClickable bool, fastMode bool) (*uiautomator2.Element, *core.ElementInfo, error) {
 	timeout := d.calculateTimeout(optional, stepTimeoutMs)
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(d.parentContext(), timeout)
 	defer cancel()
 
 	return d.findElementWithContext(ctx, sel, preferClickable, fastMode)

--- a/pkg/driver/mock/mock.go
+++ b/pkg/driver/mock/mock.go
@@ -2,6 +2,7 @@
 package mock
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -143,6 +144,11 @@ func (d *Driver) SetFindTimeout(ms int) {
 func (d *Driver) SetWaitForIdleTimeout(ms int) error {
 	// Mock driver doesn't have actual idle timeout
 	return nil
+}
+
+// SetContext is a no-op for mock driver.
+func (d *Driver) SetContext(ctx context.Context) {
+	// Mock driver doesn't use context
 }
 
 // needsElement returns true if the step type typically returns element info.

--- a/pkg/driver/uiautomator2/commands.go
+++ b/pkg/driver/uiautomator2/commands.go
@@ -1470,7 +1470,7 @@ func (d *Driver) waitUntil(step *flow.WaitUntilStep) *core.CommandResult {
 		timeout = time.Duration(step.TimeoutMs) * time.Millisecond
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(d.parentContext(), timeout)
 	defer cancel()
 
 	// Determine selector for error messages

--- a/pkg/driver/uiautomator2/driver.go
+++ b/pkg/driver/uiautomator2/driver.go
@@ -65,6 +65,9 @@ type Driver struct {
 	info   *core.PlatformInfo
 	device ShellExecutor // for ADB commands (launchApp, stopApp, clearState)
 
+	// Parent context for element-finding operations (nil = context.Background())
+	ctx context.Context
+
 	// Timeouts (0 = use defaults)
 	findTimeout         int // ms, for required elements
 	optionalFindTimeout int // ms, for optional elements
@@ -88,6 +91,19 @@ func (d *Driver) screenSize() (int, int, error) {
 		return d.info.ScreenWidth, d.info.ScreenHeight, nil
 	}
 	return 0, 0, fmt.Errorf("screen dimensions not available")
+}
+
+// SetContext sets the parent context for element-finding operations.
+func (d *Driver) SetContext(ctx context.Context) {
+	d.ctx = ctx
+}
+
+// parentContext returns the parent context for element-finding operations.
+func (d *Driver) parentContext() context.Context {
+	if d.ctx != nil {
+		return d.ctx
+	}
+	return context.Background()
 }
 
 // SetFindTimeout sets the timeout for finding required elements.
@@ -291,7 +307,7 @@ func (d *Driver) findElementForTap(sel flow.Selector, optional bool, stepTimeout
 	// For relative selectors (below, above, etc.), use page source which handles them correctly
 	if sel.HasRelativeSelector() {
 		timeout := d.calculateTimeout(optional, stepTimeoutMs)
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		ctx, cancel := context.WithTimeout(d.parentContext(), timeout)
 		defer cancel()
 		return d.findElementRelativeWithContext(ctx, sel)
 	}
@@ -309,7 +325,7 @@ func (d *Driver) findElementForTap(sel flow.Selector, optional bool, stepTimeout
 	// For text-based selectors, use smart fallback strategy
 	if sel.Text != "" {
 		timeout := d.calculateTimeout(optional, stepTimeoutMs)
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		ctx, cancel := context.WithTimeout(d.parentContext(), timeout)
 		defer cancel()
 
 		return d.findElementForTapWithContext(ctx, sel)
@@ -413,7 +429,7 @@ func buildClickableOnlyStrategies(sel flow.Selector) ([]LocatorStrategy, error) 
 // Set fastMode=true for visibility checks (1 HTTP call), false for full info (3 HTTP calls).
 func (d *Driver) findElementWithOptions(sel flow.Selector, optional bool, stepTimeoutMs int, preferClickable bool, fastMode bool) (*uiautomator2.Element, *core.ElementInfo, error) {
 	timeout := d.calculateTimeout(optional, stepTimeoutMs)
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(d.parentContext(), timeout)
 	defer cancel()
 
 	return d.findElementWithContext(ctx, sel, preferClickable, fastMode)

--- a/pkg/driver/wda/commands.go
+++ b/pkg/driver/wda/commands.go
@@ -320,7 +320,7 @@ func (d *Driver) waitForAlert(timeoutMs int, accept bool) *core.CommandResult {
 		timeoutMs = 5000
 	}
 	timeout := time.Duration(timeoutMs) * time.Millisecond
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(d.parentContext(), timeout)
 	defer cancel()
 
 	action := "accept"
@@ -968,7 +968,7 @@ func (d *Driver) waitUntil(step *flow.WaitUntilStep) *core.CommandResult {
 	}
 	timeout := time.Duration(timeoutMs) * time.Millisecond
 
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(d.parentContext(), timeout)
 	defer cancel()
 
 	// Determine selector for error messages

--- a/pkg/driver/wda/driver.go
+++ b/pkg/driver/wda/driver.go
@@ -17,6 +17,9 @@ type Driver struct {
 	info   *core.PlatformInfo
 	udid   string // Device UDID for simctl commands
 
+	// Parent context for element-finding operations (nil = context.Background())
+	ctx context.Context
+
 	// App file path for clearState (uninstall+reinstall)
 	appFile string
 
@@ -46,6 +49,19 @@ func (d *Driver) screenSize() (int, int, error) {
 		return d.info.ScreenWidth, d.info.ScreenHeight, nil
 	}
 	return 0, 0, fmt.Errorf("screen dimensions not available")
+}
+
+// SetContext sets the parent context for element-finding operations.
+func (d *Driver) SetContext(ctx context.Context) {
+	d.ctx = ctx
+}
+
+// parentContext returns the parent context for element-finding operations.
+func (d *Driver) parentContext() context.Context {
+	if d.ctx != nil {
+		return d.ctx
+	}
+	return context.Background()
 }
 
 // SetFindTimeout sets the timeout for finding required elements.
@@ -239,7 +255,7 @@ func (d *Driver) GetPlatformInfo() *core.PlatformInfo {
 // findElement finds an element using a selector with polling.
 func (d *Driver) findElement(sel flow.Selector, optional bool, stepTimeoutMs int) (*core.ElementInfo, error) {
 	timeout := d.calculateTimeout(optional, stepTimeoutMs)
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(d.parentContext(), timeout)
 	defer cancel()
 
 	return d.findElementWithContext(ctx, sel)
@@ -288,7 +304,7 @@ func (d *Driver) findElementForTap(sel flow.Selector, optional bool, stepTimeout
 	// For relative selectors, use page source which handles them correctly
 	if sel.HasRelativeSelector() {
 		timeout := d.calculateTimeout(optional, stepTimeoutMs)
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		ctx, cancel := context.WithTimeout(d.parentContext(), timeout)
 		defer cancel()
 		return d.findElementRelativeWithContext(ctx, sel)
 	}
@@ -307,7 +323,7 @@ func (d *Driver) findElementForTap(sel flow.Selector, optional bool, stepTimeout
 	// For text-based selectors, use smart fallback strategy
 	if sel.Text != "" {
 		timeout := d.calculateTimeout(optional, stepTimeoutMs)
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		ctx, cancel := context.WithTimeout(d.parentContext(), timeout)
 		defer cancel()
 		return d.findElementForTapWithContext(ctx, sel)
 	}

--- a/pkg/executor/flow_runner.go
+++ b/pkg/executor/flow_runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/devicelab-dev/maestro-runner/pkg/core"
@@ -31,6 +32,8 @@ type FlowRunner struct {
 	stepsSkipped int
 	// Sub-command tracking for compound steps (runFlow, repeat, retry)
 	subCommands []report.Command
+	// Active runFlow timeout label (e.g. "3s") for enriching sub-step errors
+	runFlowTimeout string
 }
 
 // Run executes the flow and returns the result.
@@ -47,6 +50,9 @@ func (fr *FlowRunner) Run() FlowResult {
 	// Initialize script engine
 	fr.script = NewScriptEngine()
 	defer fr.script.Close()
+
+	// Set parent context on driver so element-finding respects cancellation
+	fr.driver.SetContext(fr.ctx)
 
 	// Import system environment variables
 	fr.script.ImportSystemEnv()
@@ -539,6 +545,23 @@ func (fr *FlowRunner) executeRunFlow(step *flow.RunFlowStep) *core.CommandResult
 		}
 	}
 
+	// Apply runFlow timeout if specified
+	if step.TimeoutMs > 0 {
+		timeout := time.Duration(step.TimeoutMs) * time.Millisecond
+		ctx, cancel := context.WithTimeout(fr.ctx, timeout)
+		defer cancel()
+		origCtx := fr.ctx
+		origTimeout := fr.runFlowTimeout
+		fr.ctx = ctx
+		fr.runFlowTimeout = timeout.String()
+		fr.driver.SetContext(ctx)
+		defer func() {
+			fr.ctx = origCtx
+			fr.runFlowTimeout = origTimeout
+			fr.driver.SetContext(origCtx)
+		}()
+	}
+
 	// Report nested flow start
 	if fr.config.OnNestedFlowStart != nil && step.File != "" {
 		fr.config.OnNestedFlowStart(fr.depth+1, "Run "+step.File)
@@ -551,12 +574,28 @@ func (fr *FlowRunner) executeRunFlow(step *flow.RunFlowStep) *core.CommandResult
 	// Apply env variables with restore
 	defer fr.script.withEnvVars(step.Env)()
 
+	// Format timeout limit for error messages
+	timeoutLimit := ""
+	if step.TimeoutMs > 0 {
+		timeoutLimit = (time.Duration(step.TimeoutMs) * time.Millisecond).String()
+	}
+
 	// Execute inline steps if present
 	if len(step.Steps) > 0 {
+		var lastStep string
 		for _, nestedStep := range step.Steps {
+			if fr.ctx.Err() != nil {
+				msg := fmt.Sprintf("runFlow timed out (%s timeout) — last completed: %s", timeoutLimit, lastStep)
+				return &core.CommandResult{
+					Success: false,
+					Error:   fmt.Errorf("%s", msg),
+					Message: msg,
+				}
+			}
+			lastStep = nestedStep.Describe()
 			result := fr.executeNestedStep(nestedStep)
 			if !result.Success && !nestedStep.IsOptional() {
-				return result
+				return fr.wrapRunFlowTimeout(result, step, lastStep, timeoutLimit)
 			}
 		}
 		return &core.CommandResult{
@@ -584,7 +623,62 @@ func (fr *FlowRunner) executeRunFlow(step *flow.RunFlowStep) *core.CommandResult
 		}
 	}
 
-	return fr.executeSubFlow(*subFlow)
+	result := fr.executeSubFlow(*subFlow)
+	if !result.Success {
+		return fr.wrapRunFlowTimeout(result, step, "", timeoutLimit)
+	}
+	return result
+}
+
+// wrapRunFlowTimeout replaces cryptic context errors with a clear timeout message
+// when a runFlow step fails due to its timeout expiring.
+func (fr *FlowRunner) wrapRunFlowTimeout(result *core.CommandResult, step *flow.RunFlowStep, lastStep, timeoutLimit string) *core.CommandResult {
+	if timeoutLimit == "" || fr.ctx.Err() == nil {
+		return result // not a timeout — return original error
+	}
+
+	// Build informative message: include timeout value, flow file, and what was running
+	var msg string
+	if step.File != "" {
+		msg = fmt.Sprintf("runFlow '%s' timed out (%s timeout)", step.File, timeoutLimit)
+	} else {
+		msg = fmt.Sprintf("runFlow timed out (%s timeout)", timeoutLimit)
+	}
+	if lastStep != "" {
+		msg += fmt.Sprintf(" while executing: %s", lastStep)
+	}
+
+	return &core.CommandResult{
+		Success: false,
+		Error:   fmt.Errorf("%s", msg),
+		Message: msg,
+	}
+}
+
+// enrichTimeoutError replaces cryptic "context deadline exceeded" in sub-step errors
+// with a message that references the active runFlow timeout.
+func (fr *FlowRunner) enrichTimeoutError(result *core.CommandResult) *core.CommandResult {
+	timeout := fr.runFlowTimeout
+	enriched := *result // shallow copy
+
+	reason := fmt.Sprintf("runFlow timeout (%s) exceeded", timeout)
+
+	if enriched.Error != nil {
+		orig := enriched.Error.Error()
+		// Replace the cryptic Go context error with timeout context
+		cleaned := strings.ReplaceAll(orig, "context deadline exceeded", reason)
+		if cleaned == orig {
+			// No replacement happened — append the timeout info
+			cleaned = orig + " (" + reason + ")"
+		}
+		enriched.Error = fmt.Errorf("%s", cleaned)
+	}
+
+	if enriched.Message != "" {
+		enriched.Message = strings.ReplaceAll(enriched.Message, "context deadline exceeded", reason)
+	}
+
+	return &enriched
 }
 
 // executeNestedStep executes a step without report tracking (for nested execution).
@@ -657,6 +751,11 @@ func (fr *FlowRunner) executeNestedStep(step flow.Step) *core.CommandResult {
 
 	duration := time.Since(start).Milliseconds()
 
+	// Enrich sub-step errors with runFlow timeout context
+	if !result.Success && fr.runFlowTimeout != "" && fr.ctx.Err() != nil {
+		result = fr.enrichTimeoutError(result)
+	}
+
 	// Track nested step counts (compound steps like runFlow/repeat/retry don't count themselves)
 	if !isCompoundStep {
 		if result.Success {
@@ -725,14 +824,20 @@ func (fr *FlowRunner) executeSubFlow(subFlow flow.Flow) *core.CommandResult {
 	defer fr.script.withEnvVars(subFlow.Config.Env)()
 
 	// Execute steps
+	var lastStepDesc string
 	for _, step := range subFlow.Steps {
 		if fr.ctx.Err() != nil {
+			msg := "Sub-flow cancelled"
+			if lastStepDesc != "" {
+				msg = fmt.Sprintf("Sub-flow cancelled after: %s", lastStepDesc)
+			}
 			return &core.CommandResult{
 				Success: false,
 				Error:   fr.ctx.Err(),
-				Message: "Sub-flow cancelled",
+				Message: msg,
 			}
 		}
+		lastStepDesc = step.Describe()
 
 		// Inject subflow's appId into app lifecycle steps (same as executeStep does for main flow)
 		switch s := step.(type) {

--- a/pkg/executor/runner_test.go
+++ b/pkg/executor/runner_test.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -64,6 +65,10 @@ func (m *mockDriver) SetFindTimeout(ms int) {
 func (m *mockDriver) SetWaitForIdleTimeout(ms int) error {
 	// no-op for mock
 	return nil
+}
+
+func (m *mockDriver) SetContext(ctx context.Context) {
+	// no-op for mock
 }
 
 func TestRunner_Run_AllPassed(t *testing.T) {
@@ -940,6 +945,224 @@ func TestRunner_RunFlowStep_NoFileOrSteps(t *testing.T) {
 	// Should fail - no file or steps
 	if result.Status != report.StatusFailed {
 		t.Errorf("Status = %v, want %v", result.Status, report.StatusFailed)
+	}
+}
+
+func TestRunner_RunFlowStep_Timeout(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	execCount := 0
+	driver := &mockDriver{
+		executeFunc: func(step flow.Step) *core.CommandResult {
+			execCount++
+			// Each step takes 100ms
+			time.Sleep(100 * time.Millisecond)
+			return &core.CommandResult{Success: true}
+		},
+	}
+
+	runner := New(driver, RunnerConfig{
+		OutputDir:   tmpDir,
+		Parallelism: 0,
+		Artifacts:   ArtifactNever,
+		Device:      report.Device{ID: "test", Platform: "android"},
+	})
+
+	// runFlow with 250ms timeout containing 5 steps (each takes 100ms)
+	// Should only complete ~2 steps before timeout
+	flows := []flow.Flow{
+		{
+			SourcePath: "test.yaml",
+			Config:     flow.Config{Name: "RunFlow Timeout Test"},
+			Steps: []flow.Step{
+				&flow.RunFlowStep{
+					BaseStep: flow.BaseStep{StepType: flow.StepRunFlow, TimeoutMs: 250},
+					Steps: []flow.Step{
+						&flow.TapOnStep{BaseStep: flow.BaseStep{StepType: flow.StepTapOn}},
+						&flow.TapOnStep{BaseStep: flow.BaseStep{StepType: flow.StepTapOn}},
+						&flow.TapOnStep{BaseStep: flow.BaseStep{StepType: flow.StepTapOn}},
+						&flow.TapOnStep{BaseStep: flow.BaseStep{StepType: flow.StepTapOn}},
+						&flow.TapOnStep{BaseStep: flow.BaseStep{StepType: flow.StepTapOn}},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := runner.Run(context.Background(), flows)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	// Should fail due to timeout
+	if result.Status != report.StatusFailed {
+		t.Errorf("Status = %v, want %v", result.Status, report.StatusFailed)
+	}
+
+	// Should NOT have executed all 5 steps
+	if execCount >= 5 {
+		t.Errorf("execCount = %d, want < 5 (timeout should stop execution)", execCount)
+	}
+}
+
+func TestRunner_RunFlowStep_TimeoutNotExceeded(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	execCount := 0
+	driver := &mockDriver{
+		executeFunc: func(step flow.Step) *core.CommandResult {
+			execCount++
+			return &core.CommandResult{Success: true}
+		},
+	}
+
+	runner := New(driver, RunnerConfig{
+		OutputDir:   tmpDir,
+		Parallelism: 0,
+		Artifacts:   ArtifactNever,
+		Device:      report.Device{ID: "test", Platform: "android"},
+	})
+
+	// runFlow with generous timeout — all steps should complete
+	flows := []flow.Flow{
+		{
+			SourcePath: "test.yaml",
+			Config:     flow.Config{Name: "RunFlow No Timeout Test"},
+			Steps: []flow.Step{
+				&flow.RunFlowStep{
+					BaseStep: flow.BaseStep{StepType: flow.StepRunFlow, TimeoutMs: 5000},
+					Steps: []flow.Step{
+						&flow.TapOnStep{BaseStep: flow.BaseStep{StepType: flow.StepTapOn}},
+						&flow.TapOnStep{BaseStep: flow.BaseStep{StepType: flow.StepTapOn}},
+						&flow.TapOnStep{BaseStep: flow.BaseStep{StepType: flow.StepTapOn}},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := runner.Run(context.Background(), flows)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if result.Status != report.StatusPassed {
+		t.Errorf("Status = %v, want %v", result.Status, report.StatusPassed)
+	}
+
+	if execCount != 3 {
+		t.Errorf("execCount = %d, want 3", execCount)
+	}
+}
+
+func TestRunner_RunFlowStep_InlineStepFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	execCount := 0
+	driver := &mockDriver{
+		executeFunc: func(step flow.Step) *core.CommandResult {
+			execCount++
+			// Second step fails
+			if execCount == 2 {
+				return &core.CommandResult{Success: false, Error: fmt.Errorf("step failed")}
+			}
+			return &core.CommandResult{Success: true}
+		},
+	}
+
+	runner := New(driver, RunnerConfig{
+		OutputDir:   tmpDir,
+		Parallelism: 0,
+		Artifacts:   ArtifactNever,
+		Device:      report.Device{ID: "test", Platform: "android"},
+	})
+
+	flows := []flow.Flow{
+		{
+			SourcePath: "test.yaml",
+			Config:     flow.Config{Name: "Inline Failure Test"},
+			Steps: []flow.Step{
+				&flow.RunFlowStep{
+					BaseStep: flow.BaseStep{StepType: flow.StepRunFlow},
+					Steps: []flow.Step{
+						&flow.TapOnStep{BaseStep: flow.BaseStep{StepType: flow.StepTapOn}},
+						&flow.TapOnStep{BaseStep: flow.BaseStep{StepType: flow.StepTapOn}}, // fails
+						&flow.TapOnStep{BaseStep: flow.BaseStep{StepType: flow.StepTapOn}}, // should not run
+					},
+				},
+			},
+		},
+	}
+
+	result, err := runner.Run(context.Background(), flows)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if result.Status != report.StatusFailed {
+		t.Errorf("Status = %v, want %v", result.Status, report.StatusFailed)
+	}
+
+	// Third step should not execute
+	if execCount != 2 {
+		t.Errorf("execCount = %d, want 2", execCount)
+	}
+}
+
+func TestRunner_RunFlowStep_ExternalFileWithCallback(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a sub-flow file
+	subFlowContent := `appId: com.test
+---
+- tapOn: "OK"
+`
+	subFlowPath := filepath.Join(tmpDir, "sub.yaml")
+	if err := os.WriteFile(subFlowPath, []byte(subFlowContent), 0644); err != nil {
+		t.Fatalf("Failed to write sub-flow: %v", err)
+	}
+
+	nestedFlowStarted := false
+	driver := &mockDriver{
+		executeFunc: func(step flow.Step) *core.CommandResult {
+			return &core.CommandResult{Success: true}
+		},
+	}
+
+	runner := New(driver, RunnerConfig{
+		OutputDir:   tmpDir,
+		Parallelism: 0,
+		Artifacts:   ArtifactNever,
+		Device:      report.Device{ID: "test", Platform: "android"},
+		OnNestedFlowStart: func(depth int, name string) {
+			nestedFlowStarted = true
+		},
+	})
+
+	flows := []flow.Flow{
+		{
+			SourcePath: filepath.Join(tmpDir, "main.yaml"),
+			Config:     flow.Config{Name: "Callback Test"},
+			Steps: []flow.Step{
+				&flow.RunFlowStep{
+					BaseStep: flow.BaseStep{StepType: flow.StepRunFlow},
+					File:     "sub.yaml",
+				},
+			},
+		},
+	}
+
+	result, err := runner.Run(context.Background(), flows)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if result.Status != report.StatusPassed {
+		t.Errorf("Status = %v, want %v", result.Status, report.StatusPassed)
+	}
+
+	if !nestedFlowStarted {
+		t.Error("OnNestedFlowStart callback was not called")
 	}
 }
 

--- a/pkg/flow/parser.go
+++ b/pkg/flow/parser.go
@@ -785,6 +785,7 @@ func parseRunFlowStep(valueNode *yaml.Node, sourcePath string) (Step, error) {
 		Env      map[string]string `yaml:"env"`
 		Optional bool              `yaml:"optional"`
 		Label    string            `yaml:"label"`
+		Timeout  int               `yaml:"timeout"`
 	}
 
 	if err := valueNode.Decode(&raw); err != nil {
@@ -796,6 +797,7 @@ func parseRunFlowStep(valueNode *yaml.Node, sourcePath string) (Step, error) {
 	s.Env = raw.Env
 	s.Optional = raw.Optional
 	s.StepLabel = raw.Label
+	s.TimeoutMs = raw.Timeout
 
 	for _, cmdNode := range raw.Commands {
 		step, err := parseStep(&cmdNode, sourcePath)

--- a/pkg/flow/parser_test.go
+++ b/pkg/flow/parser_test.go
@@ -364,6 +364,55 @@ func TestParse_RunFlowWithInlineSteps(t *testing.T) {
 	}
 }
 
+func TestParse_RunFlowWithTimeout(t *testing.T) {
+	yaml := `
+- runFlow:
+    file: login.yaml
+    timeout: 5000
+    env:
+      user: test
+`
+	flow, err := Parse([]byte(yaml), "test.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	runFlow, ok := flow.Steps[0].(*RunFlowStep)
+	if !ok {
+		t.Fatalf("expected RunFlowStep, got %T", flow.Steps[0])
+	}
+	if runFlow.TimeoutMs != 5000 {
+		t.Errorf("expected TimeoutMs=5000, got %d", runFlow.TimeoutMs)
+	}
+	if runFlow.File != "login.yaml" {
+		t.Errorf("expected file=login.yaml, got %q", runFlow.File)
+	}
+}
+
+func TestParse_RunFlowInlineWithTimeout(t *testing.T) {
+	yaml := `
+- runFlow:
+    timeout: 3000
+    commands:
+      - assertVisible: "Hello"
+`
+	flow, err := Parse([]byte(yaml), "test.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	runFlow, ok := flow.Steps[0].(*RunFlowStep)
+	if !ok {
+		t.Fatalf("expected RunFlowStep, got %T", flow.Steps[0])
+	}
+	if runFlow.TimeoutMs != 3000 {
+		t.Errorf("expected TimeoutMs=3000, got %d", runFlow.TimeoutMs)
+	}
+	if len(runFlow.Steps) != 1 {
+		t.Errorf("expected 1 inline step, got %d", len(runFlow.Steps))
+	}
+}
+
 func TestParse_NestedRepeat(t *testing.T) {
 	yaml := `
 - repeat:

--- a/pkg/flutter/wrapper.go
+++ b/pkg/flutter/wrapper.go
@@ -36,11 +36,12 @@ type FlutterDriver struct {
 	client        *VMServiceClient
 	dev           DeviceExecutor
 	appID         string
-	socketPath    string // Unix socket path for VM Service forwarding (Android)
-	udid          string // iOS simulator UDID (empty for Android)
-	isIOS         bool   // true = iOS reconnection path
-	attempted     bool   // true after first discovery attempt (avoids retrying every step)
-	findTimeoutMs int    // current find timeout set by executor (0 = driver default)
+	socketPath    string          // Unix socket path for VM Service forwarding (Android)
+	udid          string          // iOS simulator UDID (empty for Android)
+	isIOS         bool            // true = iOS reconnection path
+	attempted     bool            // true after first discovery attempt (avoids retrying every step)
+	findTimeoutMs int             // current find timeout set by executor (0 = driver default)
+	ctx           context.Context // Parent context for element-finding operations (runFlow timeout)
 }
 
 // Wrap creates a FlutterDriver that wraps the given inner driver.
@@ -111,7 +112,7 @@ func (d *FlutterDriver) Execute(step flow.Step) *core.CommandResult {
 	// --- Parallel search: inner driver (1s polls) + Flutter (continuous goroutine) ---
 
 	// Start Flutter polling in background goroutine
-	searchCtx, searchCancel := context.WithTimeout(context.Background(), time.Duration(effectiveTimeout)*time.Millisecond)
+	searchCtx, searchCancel := context.WithTimeout(d.parentContext(), time.Duration(effectiveTimeout)*time.Millisecond)
 	flutterCh := make(chan *flutterSearchResult, 1)
 	go d.flutterPollLoop(searchCtx, sel, flutterCh)
 
@@ -121,6 +122,14 @@ func (d *FlutterDriver) Execute(step flow.Step) *core.CommandResult {
 	var result *core.CommandResult
 
 	for time.Now().Before(deadline) {
+		// Check if parent context (e.g. runFlow timeout) was cancelled
+		if err := d.parentContext().Err(); err != nil {
+			searchCancel()
+			<-flutterCh
+			d.inner.SetFindTimeout(d.findTimeoutMs)
+			return core.ErrorResult(fmt.Errorf("element %q not found: %w", sel.Describe(), err), "")
+		}
+
 		d.inner.SetFindTimeout(innerPollTimeout)
 		result = d.inner.Execute(step)
 
@@ -539,6 +548,17 @@ func (d *FlutterDriver) SetFindTimeout(ms int) {
 }
 func (d *FlutterDriver) SetWaitForIdleTimeout(ms int) error {
 	return d.inner.SetWaitForIdleTimeout(ms)
+}
+func (d *FlutterDriver) SetContext(ctx context.Context) {
+	d.ctx = ctx
+	d.inner.SetContext(ctx)
+}
+
+func (d *FlutterDriver) parentContext() context.Context {
+	if d.ctx != nil {
+		return d.ctx
+	}
+	return context.Background()
 }
 
 // --- Optional interface forwarding ---

--- a/pkg/flutter/wrapper_test.go
+++ b/pkg/flutter/wrapper_test.go
@@ -1,6 +1,7 @@
 package flutter
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -28,6 +29,7 @@ func (m *mockDriver) GetState() *core.StateSnapshot          { return &core.Stat
 func (m *mockDriver) GetPlatformInfo() *core.PlatformInfo    { return &core.PlatformInfo{} }
 func (m *mockDriver) SetFindTimeout(ms int)                  {}
 func (m *mockDriver) SetWaitForIdleTimeout(ms int) error     { return nil }
+func (m *mockDriver) SetContext(context.Context)              {}
 
 func TestFlutterDriver_PassThrough_Success(t *testing.T) {
 	inner := &mockDriver{


### PR DESCRIPTION
## Summary

- Add `timeout` parameter to `runFlow` steps (milliseconds) that propagates into driver polling loops via `SetContext(ctx)`, enabling mid-operation cancellation when the timeout expires
- All drivers updated: uiautomator2, wda, appium, devicelab, flutter, mock
- Informative error messages show timeout value, flow file, and which step was executing
- Timeout failures classified as **TIMEOUT** error type in HTML, JUnit, and Allure reports

### Example usage

```yaml
- runFlow:
    file: common/login.yaml
    timeout: 5000       # 5 second timeout
    env:
      username: devicelab

- runFlow:
    timeout: 3000       # inline steps with timeout
    commands:
      - tapOn: "Submit"
      - assertVisible: "Success"
```

### Error messages

```
runFlow 'common/login.yaml' timed out (2s timeout)
runFlow timed out (3s timeout) while executing: assertVisible: text="THIS_ELEMENT_DOES_NOT_EXIST"
element "Username" not found: runFlow timeout (2s) exceeded
```

## Test plan

- [x] 4 executor unit tests + 2 parser unit tests
- [x] Validated on real Android device (Pixel 4a) — 20 flows, 18 pass, 2 expected timeout failures
- [x] Validated on iOS simulator (iPhone 16 Pro) — 20 flows, 14 pass, 2 expected timeout failures + 4 pre-existing iOS test issues
- [x] No regressions in existing test suites

Ref #29 — Thanks to @maraujop for the suggestion!