### PR TITLE
fix: atomic FindAndClick for ID selectors + SendKeyActions fallback

### DIFF
--- a/pkg/driver/devicelab/commands.go
+++ b/pkg/driver/devicelab/commands.go
@@ -30,10 +30,11 @@ func (d *Driver) tapOn(step *flow.TapOnStep) *core.CommandResult {
 		return result
 	}
 
-	// For text-based taps, use FindAndClick —
+	// For text-based and ID-based taps, use FindAndClick —
 	// single atomic Java call: find node + coordinate click at center.
 	// No stale nodes, no performAction, no parent walk-up.
-	if step.Selector.Text != "" && step.Point == "" && !step.Selector.HasRelativeSelector() {
+	// Prevents stale coordinates caused by Compose recomposition between find and click.
+	if (step.Selector.Text != "" || step.Selector.ID != "") && step.Point == "" && !step.Selector.HasRelativeSelector() {
 		strategies, err := buildSelectors(step.Selector, 0)
 		if err != nil {
 			return errorResult(err, fmt.Sprintf("Failed to build selectors: %v", err))
@@ -283,7 +284,13 @@ func (d *Driver) inputText(step *flow.InputTextStep) *core.CommandResult {
 			return successResult(fmt.Sprintf("Entered text: %s%s", text, unicodeWarning), nil)
 		}
 		if err := active.SendKeys(text); err != nil {
-			return errorResult(err, fmt.Sprintf("Failed to input text: %v", err))
+			// Fallback to SendKeyActions when SendKeys fails (e.g., stale element
+			// reference from Compose recomposition after tapping an EditText).
+			logger.Warn("SendKeys failed (%v), falling back to SendKeyActions", err)
+			if keyErr := d.client.SendKeyActions(text); keyErr != nil {
+				return errorResult(err, fmt.Sprintf("Failed to input text: %v (SendKeyActions fallback also failed: %v)", err, keyErr))
+			}
+			return successResult(fmt.Sprintf("Entered text (fallback): %s%s", text, unicodeWarning), nil)
 		}
 	}
 

--- a/pkg/driver/devicelab/commands_test.go
+++ b/pkg/driver/devicelab/commands_test.go
@@ -1,7 +1,9 @@
 package devicelab
 
 import (
+	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -10,12 +12,15 @@ import (
 	"github.com/devicelab-dev/maestro-runner/pkg/uiautomator2"
 )
 
-// mockDeviceLabClient is a minimal mock for scrollUntilVisible tests.
+// mockDeviceLabClient is a minimal mock for tests.
 type mockDeviceLabClient struct {
-	sourceFunc     func() (string, error)
-	scrollCalls    int
-	scrollErr      error
-	findClickCalls int
+	sourceFunc         func() (string, error)
+	findAndClickFunc   func(strategy, selector string) (*uiautomator2.Element, error)
+	activeElementFunc  func() (*uiautomator2.Element, error)
+	sendKeyActionsFunc func(text string) error
+	scrollCalls        int
+	scrollErr          error
+	findClickCalls     int
 }
 
 func (m *mockDeviceLabClient) FindElement(strategy, selector string) (*uiautomator2.Element, error) {
@@ -23,9 +28,17 @@ func (m *mockDeviceLabClient) FindElement(strategy, selector string) (*uiautomat
 }
 func (m *mockDeviceLabClient) FindAndClick(strategy, selector string) (*uiautomator2.Element, error) {
 	m.findClickCalls++
+	if m.findAndClickFunc != nil {
+		return m.findAndClickFunc(strategy, selector)
+	}
 	return nil, nil
 }
-func (m *mockDeviceLabClient) ActiveElement() (*uiautomator2.Element, error) { return nil, nil }
+func (m *mockDeviceLabClient) ActiveElement() (*uiautomator2.Element, error) {
+	if m.activeElementFunc != nil {
+		return m.activeElementFunc()
+	}
+	return nil, nil
+}
 func (m *mockDeviceLabClient) SetImplicitWait(timeout time.Duration) error   { return nil }
 func (m *mockDeviceLabClient) Click(x, y int) error                          { return nil }
 func (m *mockDeviceLabClient) DoubleClick(x, y int) error                    { return nil }
@@ -44,7 +57,12 @@ func (m *mockDeviceLabClient) SwipeInArea(area uiautomator2.RectModel, direction
 func (m *mockDeviceLabClient) Back() error                       { return nil }
 func (m *mockDeviceLabClient) HideKeyboard() error               { return nil }
 func (m *mockDeviceLabClient) PressKeyCode(keyCode int) error    { return nil }
-func (m *mockDeviceLabClient) SendKeyActions(text string) error  { return nil }
+func (m *mockDeviceLabClient) SendKeyActions(text string) error {
+	if m.sendKeyActionsFunc != nil {
+		return m.sendKeyActionsFunc(text)
+	}
+	return nil
+}
 func (m *mockDeviceLabClient) Screenshot() ([]byte, error)       { return nil, nil }
 func (m *mockDeviceLabClient) Source() (string, error)           { return m.sourceFunc() }
 func (m *mockDeviceLabClient) GetOrientation() (string, error)   { return "PORTRAIT", nil }
@@ -124,6 +142,136 @@ func TestScrollUntilVisibleRespectsTimeout(t *testing.T) {
 		t.Errorf("Expected timeout to limit scrolls (got %d, default max is 20)", client.scrollCalls)
 	}
 }
+
+// ============================================================================
+// TapOn — ID selector uses atomic FindAndClick
+// ============================================================================
+
+func TestTapOnIDSelectorUsesAtomicFindAndClick(t *testing.T) {
+	client := &mockDeviceLabClient{
+		sourceFunc: func() (string, error) { return "", nil },
+		findAndClickFunc: func(strategy, selector string) (*uiautomator2.Element, error) {
+			return uiautomator2.NewCachedElement("elem-1", "Hello", uiautomator2.ElementRect{
+				X: 100, Y: 200, Width: 50, Height: 30,
+			}), nil
+		},
+	}
+
+	driver := New(client, &core.PlatformInfo{ScreenWidth: 1080, ScreenHeight: 2400}, nil)
+	step := &flow.TapOnStep{
+		Selector: flow.Selector{ID: "my_button"},
+	}
+
+	result := driver.tapOn(step)
+
+	if !result.Success {
+		t.Errorf("Expected success, got error: %v", result.Error)
+	}
+	if client.findClickCalls != 1 {
+		t.Errorf("Expected 1 FindAndClick call, got %d", client.findClickCalls)
+	}
+	if result.Message != "Tapped on element" {
+		t.Errorf("Expected 'Tapped on element', got %q", result.Message)
+	}
+}
+
+func TestTapOnTextSelectorUsesAtomicFindAndClick(t *testing.T) {
+	client := &mockDeviceLabClient{
+		sourceFunc: func() (string, error) { return "", nil },
+		findAndClickFunc: func(strategy, selector string) (*uiautomator2.Element, error) {
+			return uiautomator2.NewCachedElement("elem-2", "Submit", uiautomator2.ElementRect{
+				X: 50, Y: 100, Width: 200, Height: 40,
+			}), nil
+		},
+	}
+
+	driver := New(client, &core.PlatformInfo{ScreenWidth: 1080, ScreenHeight: 2400}, nil)
+	step := &flow.TapOnStep{
+		Selector: flow.Selector{Text: "Submit"},
+	}
+
+	result := driver.tapOn(step)
+
+	if !result.Success {
+		t.Errorf("Expected success, got error: %v", result.Error)
+	}
+	if client.findClickCalls != 1 {
+		t.Errorf("Expected 1 FindAndClick call, got %d", client.findClickCalls)
+	}
+}
+
+// ============================================================================
+// InputText — SendKeys fallback to SendKeyActions
+// ============================================================================
+
+func TestInputTextSendKeysFallbackToSendKeyActions(t *testing.T) {
+	sendKeyActionsCalled := false
+	client := &mockDeviceLabClient{
+		sourceFunc: func() (string, error) { return "", nil },
+		activeElementFunc: func() (*uiautomator2.Element, error) {
+			elem := uiautomator2.NewCachedElement("active-1", "", uiautomator2.ElementRect{})
+			elem.SetSendKeysFunc(func(text string) error {
+				return errors.New("stale element reference")
+			})
+			return elem, nil
+		},
+		sendKeyActionsFunc: func(text string) error {
+			sendKeyActionsCalled = true
+			return nil
+		},
+	}
+
+	driver := New(client, &core.PlatformInfo{ScreenWidth: 1080, ScreenHeight: 2400}, nil)
+	step := &flow.InputTextStep{
+		Text: "hello",
+	}
+
+	result := driver.inputText(step)
+
+	if !result.Success {
+		t.Errorf("Expected success, got error: %v", result.Error)
+	}
+	if !sendKeyActionsCalled {
+		t.Error("Expected SendKeyActions fallback to be called")
+	}
+	if !strings.Contains(result.Message, "fallback") {
+		t.Errorf("Expected fallback in message, got %q", result.Message)
+	}
+}
+
+func TestInputTextSendKeysFallbackAlsoFails(t *testing.T) {
+	client := &mockDeviceLabClient{
+		sourceFunc: func() (string, error) { return "", nil },
+		activeElementFunc: func() (*uiautomator2.Element, error) {
+			elem := uiautomator2.NewCachedElement("active-1", "", uiautomator2.ElementRect{})
+			elem.SetSendKeysFunc(func(text string) error {
+				return errors.New("stale element reference")
+			})
+			return elem, nil
+		},
+		sendKeyActionsFunc: func(text string) error {
+			return errors.New("key actions failed")
+		},
+	}
+
+	driver := New(client, &core.PlatformInfo{ScreenWidth: 1080, ScreenHeight: 2400}, nil)
+	step := &flow.InputTextStep{
+		Text: "hello",
+	}
+
+	result := driver.inputText(step)
+
+	if result.Success {
+		t.Error("Expected failure when both SendKeys and SendKeyActions fail")
+	}
+	if !strings.Contains(result.Message, "SendKeyActions fallback also failed") {
+		t.Errorf("Expected both errors in message, got %q", result.Message)
+	}
+}
+
+// ============================================================================
+// ScrollUntilVisible tests
+// ============================================================================
 
 func TestScrollUntilVisibleDefaultMaxScrolls(t *testing.T) {
 	client := &mockDeviceLabClient{

--- a/pkg/driver/uiautomator2/commands.go
+++ b/pkg/driver/uiautomator2/commands.go
@@ -275,7 +275,13 @@ func (d *Driver) inputText(step *flow.InputTextStep) *core.CommandResult {
 			return successResult(fmt.Sprintf("Entered text: %s%s", text, unicodeWarning), nil)
 		}
 		if err := active.SendKeys(text); err != nil {
-			return errorResult(err, fmt.Sprintf("Failed to input text: %v", err))
+			// Fallback to SendKeyActions when SendKeys fails (e.g., stale element
+			// reference from Compose recomposition after tapping an EditText).
+			logger.Warn("SendKeys failed (%v), falling back to SendKeyActions", err)
+			if keyErr := d.client.SendKeyActions(text); keyErr != nil {
+				return errorResult(err, fmt.Sprintf("Failed to input text: %v (SendKeyActions fallback also failed: %v)", err, keyErr))
+			}
+			return successResult(fmt.Sprintf("Entered text (fallback): %s%s", text, unicodeWarning), nil)
 		}
 	}
 

--- a/pkg/driver/uiautomator2/commands_test.go
+++ b/pkg/driver/uiautomator2/commands_test.go
@@ -4169,6 +4169,73 @@ func TestScrollUntilVisibleDefaultMaxScrolls(t *testing.T) {
 }
 
 // ============================================================================
+// InputText — SendKeys fallback to SendKeyActions
+// ============================================================================
+
+func TestInputTextSendKeysFallbackToSendKeyActions(t *testing.T) {
+	sendKeyActionsCalled := false
+	client := &MockUIA2Client{
+		activeElementFunc: func() (*uiautomator2.Element, error) {
+			elem := uiautomator2.NewCachedElement("active-1", "", uiautomator2.ElementRect{})
+			elem.SetSendKeysFunc(func(text string) error {
+				return errors.New("stale element reference")
+			})
+			return elem, nil
+		},
+		sendKeyActionsFunc: func(text string) error {
+			sendKeyActionsCalled = true
+			return nil
+		},
+	}
+
+	driver := New(client, &core.PlatformInfo{ScreenWidth: 1080, ScreenHeight: 2400}, nil)
+	step := &flow.InputTextStep{
+		Text: "hello",
+	}
+
+	result := driver.inputText(step)
+
+	if !result.Success {
+		t.Errorf("Expected success, got error: %v", result.Error)
+	}
+	if !sendKeyActionsCalled {
+		t.Error("Expected SendKeyActions fallback to be called")
+	}
+	if !strings.Contains(result.Message, "fallback") {
+		t.Errorf("Expected fallback in message, got %q", result.Message)
+	}
+}
+
+func TestInputTextSendKeysFallbackAlsoFails(t *testing.T) {
+	client := &MockUIA2Client{
+		activeElementFunc: func() (*uiautomator2.Element, error) {
+			elem := uiautomator2.NewCachedElement("active-1", "", uiautomator2.ElementRect{})
+			elem.SetSendKeysFunc(func(text string) error {
+				return errors.New("stale element reference")
+			})
+			return elem, nil
+		},
+		sendKeyActionsFunc: func(text string) error {
+			return errors.New("key actions failed")
+		},
+	}
+
+	driver := New(client, &core.PlatformInfo{ScreenWidth: 1080, ScreenHeight: 2400}, nil)
+	step := &flow.InputTextStep{
+		Text: "hello",
+	}
+
+	result := driver.inputText(step)
+
+	if result.Success {
+		t.Error("Expected failure when both SendKeys and SendKeyActions fail")
+	}
+	if !strings.Contains(result.Message, "SendKeyActions fallback also failed") {
+		t.Errorf("Expected both errors in message, got %q", result.Message)
+	}
+}
+
+// ============================================================================
 // Compile-time interface assertion
 // ============================================================================
 

--- a/pkg/driver/uiautomator2/driver_test.go
+++ b/pkg/driver/uiautomator2/driver_test.go
@@ -1585,6 +1585,10 @@ func TestInputTextNoSelectorError(t *testing.T) {
 			w.WriteHeader(http.StatusInternalServerError)
 			writeJSON(w, map[string]interface{}{"value": "send keys failed"})
 		},
+		"POST /actions": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			writeJSON(w, map[string]interface{}{"value": "key actions also failed"})
+		},
 	})
 	defer server.Close()
 


### PR DESCRIPTION
## Summary

Two fixes for Compose UI compatibility:

1. DeviceLab tapOn: extend FindAndClick atomic path to ID-based selectors (not just text). Previously, ID taps used findElementForTap + Click(x,y) which suffers from stale coordinates when Compose recomposes between the find and click steps. Now ID taps use the same atomic Java call (find node + coordinate click in one round-trip) that text taps use.

2. Both drivers inputText: when SendKeys fails on the active element (stale reference from Compose recomposition after keyboard appears), fall back to SendKeyActions (W3C key press simulation) which doesn't depend on element references.

These issues manifest when testing Jetpack Compose UIs where:
- Tapping an EditText triggers recomposition (keyboard appears)
- The DOM element reference becomes stale before SendKeys executes
- Coordinate-based clicks use stale positions after layout shifts

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

1. pkg/driver/devicelab/commands_test.go - Extended mock with configurable findAndClickFunc, activeElementFunc, sendKeyActionsFunc. Added 4 tests:
    - TestTapOnIDSelectorUsesAtomicFindAndClick — verifies ID selectors use the atomic FindAndClick path
    - TestTapOnTextSelectorUsesAtomicFindAndClick — verifies text selectors use FindAndClick (existing behavior, previously untested)
    - TestInputTextSendKeysFallbackToSendKeyActions — SendKeys fails, falls back to SendKeyActions successfully
    - TestInputTextSendKeysFallbackAlsoFails — both fail, error message includes both errors
  2. pkg/driver/uiautomator2/commands_test.go - Added 2 tests:
    - TestInputTextSendKeysFallbackToSendKeyActions — same fallback scenario
    - TestInputTextSendKeysFallbackAlsoFails — same both-fail scenario
  3. pkg/driver/uiautomator2/driver_test.go - Fixed TestInputTextNoSelectorError — added POST /actions handler returning 500, so the SendKeyActions fallback also fails (matching the test's expectation of failure).

## Related Issues

Fixes #(issue number)

## Testing

- [x] Tests pass locally (`make test`)
- [x] Linting passes (`make lint`)
- [x] Added tests for new functionality
- [ ] Tested manually with sample flows

## Checklist

- [ ] Code follows project style guidelines
- [ ] Self-reviewed the code
- [ ] Added/updated documentation as needed
- [ ] No breaking changes (or documented if breaking)
- [ ] CHANGELOG.md updated (for notable changes)
