### PR TITLE
Wire clearKeychain on iOS — standalone step + launchApp flag

### DIFF
--- a/pkg/driver/wda/commands.go
+++ b/pkg/driver/wda/commands.go
@@ -726,6 +726,15 @@ func (d *Driver) launchApp(step *flow.LaunchAppStep) *core.CommandResult {
 		wg.Wait()
 	}
 
+	// Reset simulator keychain if requested — after clearState so a reinstall
+	// can't race, before launch so the app starts with a clean keychain.
+	// No-op with a warning on real devices (keychain can't be reset there).
+	if step.ClearKeychain {
+		if r := d.resetKeychain(); !r.Success {
+			logger.Warn("launchApp: clearKeychain skipped: %s", r.Message)
+		}
+	}
+
 	if d.udid != "" {
 		d.alertAction = resolveAlertAction(permissions)
 	}
@@ -899,6 +908,33 @@ func (d *Driver) clearAppStateSimulator(bundleID string) *core.CommandResult {
 	}
 
 	return successResult(fmt.Sprintf("Cleared state for %s (uninstall+reinstall)", bundleID), nil)
+}
+
+// clearKeychain handles the standalone clearKeychain step. Unsupported on
+// real devices (iOS keychain is sandboxed and can't be reset via public API).
+func (d *Driver) clearKeychain(_ *flow.ClearKeychainStep) *core.CommandResult {
+	return d.resetKeychain()
+}
+
+// resetKeychain runs `xcrun simctl keychain <udid> reset` on the simulator.
+// Shared by the standalone step and the launchApp clearKeychain: true option.
+func (d *Driver) resetKeychain() *core.CommandResult {
+	if !d.info.IsSimulator {
+		return &core.CommandResult{
+			Success: false,
+			Error:   fmt.Errorf("clearKeychain is not supported on real iOS devices"),
+			Message: "clearKeychain requires an iOS Simulator — the iOS keychain is sandboxed on real devices and cannot be reset programmatically. Use clearState to reinstall the app, which drops its keychain entries.",
+		}
+	}
+	if d.udid == "" {
+		return errorResult(fmt.Errorf("simulator UDID required"), "clearKeychain requires a booted simulator")
+	}
+	cmd := exec.Command("xcrun", "simctl", "keychain", d.udid, "reset")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return errorResult(fmt.Errorf("simctl keychain reset failed: %w: %s", err, string(output)),
+			"Failed to reset simulator keychain")
+	}
+	return successResult("Simulator keychain reset", nil)
 }
 
 func (d *Driver) clearAppStateDevice(bundleID string) *core.CommandResult {

--- a/pkg/driver/wda/driver.go
+++ b/pkg/driver/wda/driver.go
@@ -233,6 +233,10 @@ func (d *Driver) Execute(step flow.Step) *core.CommandResult {
 	case *flow.SetPermissionsStep:
 		result = d.setPermissions(s)
 
+	// Keychain
+	case *flow.ClearKeychainStep:
+		result = d.clearKeychain(s)
+
 	default:
 		result = &core.CommandResult{
 			Success: false,


### PR DESCRIPTION
## Summary

Fixes #57. Reported by @ross-aker — thank you for the repro.

Two gaps in the WDA driver:

1. **Standalone `clearKeychain` step** hit the default case in `Execute()` dispatch and errored with `Step type '*flow.ClearKeychainStep' is not supported on iOS`.
2. **`launchApp: clearKeychain: true`** was silently a no-op — the struct has the field, but `launchApp()` never read it, so a previously-logged-in user stayed logged in even with the flag set.

## Changes

- Add `clearKeychain(step)` handler + shared `resetKeychain()` helper in `pkg/driver/wda/commands.go` that runs `xcrun simctl keychain <udid> reset` on simulators.
- Wire `*flow.ClearKeychainStep` into `driver.Execute()` dispatch.
- In `launchApp()`, fire `resetKeychain()` after `clearState` and before launch if the flag is set. Failure logs at `Warn` and does not abort the launch.

### Real-device behavior

Returns a clear "unsupported on real iOS devices" message pointing to `clearState` as an alternative (reinstall drops the app's keychain entries). The iOS keychain on real devices is sandboxed per-app and can't be reset via public API without jailbreak.

## Test plan

- [x] New test flow (standalone `clearKeychain` + `launchApp { clearKeychain: true }`) passes on iPhone 16 Pro simulator (iOS 18.6).
- [x] Existing iOS auth flow (`login-valid-primary.yaml`) still passes — no regression.
- [x] `go build ./...` + `go test ./pkg/driver/wda/...` green.
- [ ] Real device: returns the expected "unsupported" message instead of a silent no-op.