### PR TITLE
Add special LaunchAppStep handler into executeNestedStep

### DIFF
--- a/pkg/executor/flow_runner.go
+++ b/pkg/executor/flow_runner.go
@@ -795,6 +795,11 @@ func (fr *FlowRunner) executeNestedStep(step flow.Step) *core.CommandResult {
 	}
 
 	switch s := step.(type) {
+	case *flow.LaunchAppStep:
+		if s.AppID == "" {
+			s.AppID = fr.flow.Config.EffectiveAppID()
+		}
+		result = fr.driver.Execute(step)
 	case *flow.DefineVariablesStep:
 		result = fr.script.ExecuteDefineVariables(s)
 	case *flow.RunScriptStep:


### PR DESCRIPTION
## Summary

I have a possible solution to #62 implemented here, which I have verified in the following conditions:
```yaml
appId: com.google.android.deskclock
onFlowStart:
  - launchApp
```
```yaml
onFlowStart:
  - launchApp
      appId: com.google.android.deskclock
```

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

Added a new custom step condition to `executeNestedStep` for step type `*flow.LaunchAppStep`.  This case block checks to see if AppID is blank, which is true if the `launchApp` step in the flow does not include an explicit app id. 

If the AppID is blank, it is set using the default value from the flow configuration.

## Related Issues

Fixes #62 

## Testing

- [X] Tests pass locally (`make test`)
- [ ] Added tests for new functionality
- [X] Tested manually with sample flows

## Checklist

- [ ] Code follows project style guidelines
- [X] Self-reviewed the code
- [ ] Added/updated documentation as needed
- [X] No breaking changes (or documented if breaking)
- [ ] CHANGELOG.md updated (for notable changes)

## Additional Notes

I could use some quick pointers on where/how I should add test cases to validate this behavior