### PR TITLE
Saucelabs improve logs and test names

### DIFF
--- a/docs/cloud-providers/saucelabs.md
+++ b/docs/cloud-providers/saucelabs.md
@@ -1,6 +1,8 @@
-# Sauce Labs (Appium)
+# Sauce Labs
 
-Use Appium driver mode with a Sauce Labs URL and provider capabilities.
+**Maestro-runner** runs your Maestro flows on the **Sauce Labs** platform. You can target Sauce Labs **Android and iOS real devices**, as well as **Android emulators** and **iOS simulators** hosted by Sauce Labs.
+
+Maestro-runner acts as a bridge between Maestro and **Appium**: **Maestro flow YAML** is executed through an Appium session against the **Sauce Labs’ Appium endpoint**, so execution follows the same model as standard Appium tests on Sauce Labs.
 
 ## Run command
 
@@ -13,7 +15,13 @@ maestro-runner \
 ```
 
 - Default example uses `us-west-1`. Replace the Sauce Labs endpoints with your region as needed (for example `eu-central-1`, `us-east-4`).
-- The Appium URL should include Sauce credentials (`$SAUCE_USERNAME` and `$SAUCE_ACCESS_KEY`) or be provided via environment variables.
+- The Appium URL should include Sauce credentials (`$SAUCE_USERNAME` and `$SAUCE_ACCESS_KEY`).
+
+After the `test` subcommand you pass **which Maestro flows to run**. That can be:
+
+- **A directory** — e.g. `test flows/` discovers Maestro flow files (`*.yaml` / `*.yml`) **one level deep**: only files directly inside the folder you pass.
+- **One flow file** — e.g. `test flows/login.yaml`.
+- **Several flow files** — e.g. `test flow_a.yaml flow_b.yaml flow_c.yaml` (order is preserved).
 
 ## Example capabilities
 
@@ -77,12 +85,96 @@ Example `provider-caps.json` for iOS simulator:
   "appium:app": "storage:filename=SauceLabs-Demo-App.Simulator.zip",
   "sauce:options": {
     "build": "Maestro iOS Simulator Run",
-    "appiumVersion": "2.11.3"
+    "appiumVersion": "2.1.3"
   }
 }
 ```
 
+## Include and exclude tags
+
+Tags are defined **per flow** in the Maestro YAML **config** section (above the `---` that separates config from steps). Use a `tags` list of strings:
+
+```yaml
+appId: com.example.app
+name: Login Test
+tags:
+  - smoke
+  - regression
+---
+- launchApp
+- tapOn: "Login"
+```
+
+**CLI filtering**:
+
+- **`--include-tags`** — only flows that list **at least one** of the given tags are run. You can repeat the flag for multiple tags (a flow needs to match **any** of them). Example:
+
+  ```bash
+  maestro-runner --driver appium --appium-url "..." --caps provider-caps.json \
+    test --include-tags smoke --include-tags quick flows/
+  ```
+
+- **`--exclude-tags`** — flows that list **any** of these tags are skipped. Example:
+
+  ```bash
+  maestro-runner --driver appium --appium-url "..." --caps provider-caps.json \
+    test --exclude-tags slow flows/
+  ```
+
+Matching is **exact** (case-sensitive) on the tag strings in the YAML.
+
+## Job / test name (capabilities vs YAML)
+
+How the **test / job name** is chosen for a Sauce Labs job:
+
+1. **`name` in `sauce:options`**  
+   Set the test name from your capabilities by adding `name` under `sauce:options`. Sauce uses it when the session/job is created. See Sauce’s **`name`** option: [Test configuration options — `name`](https://docs.saucelabs.com/dev/test-configuration-options/#name).
+
+   Example fragment inside your caps JSON:
+
+   ```json
+   "sauce:options": {
+     "name": "My regression suite",
+     "build": "Maestro Android Run",
+     "appiumVersion": "latest"
+   }
+   ```
+
+2. **No `name` in capabilities**  
+   If you do **not** set a name that way, the name comes from the **YAML flow file**: the file’s **basename without** the `.yaml` or `.yml` extension. If **several YAML flows run in the same Appium session** (for example one worker runs multiple flows one after another), the name is taken from the **first** of those flows for that session’s Sauce job.
+
+## Parallel execution (`--parallel` with Appium)
+
+For Sauce Labs, parallel mode uses **multiple Appium sessions** on the same `--appium-url`. **Each parallel worker has exactly one Appium session** (on Sauce, usually **one device and one job** until that worker is done). Workers share a **queue** of flows: the **same session** often runs **several YAML files in sequence** when there are **more flows than workers**. When **flows and workers are equal** and all start together, **each YAML runs in its own session** at the same time.
+
+Sauce Labs assigns devices to each session according to your capabilities and account limits.
+
+Enable it with `--parallel N` (where `N` is the desired number of concurrent sessions):
+
+```bash
+maestro-runner \
+  --driver appium \
+  --parallel 3 \
+  --appium-url "https://$SAUCE_USERNAME:$SAUCE_ACCESS_KEY@ondemand.us-west-1.saucelabs.com:443/wd/hub" \
+  --caps provider-caps.json \
+  test flow_a.yaml flow_b.yaml flow_c.yaml
+```
+
+### Behaviour for three common cases
+
+1. **Number of YAML flows = number of parallel workers (sessions)**  
+   With `--parallel N` and `N` flows, the runner starts **N** Appium sessions (one per worker). **Each flow runs in its own session** because each worker takes one YAML and they all run **at the same time**, **if** your Sauce account has enough **concurrency** for `N` simultaneous sessions.
+
+2. **More YAML flows than sessions**  
+   With `--parallel N` and more than `N` flows, at most `N` flows run concurrently. The rest wait in the queue. When a worker finishes a flow, it **takes the next YAML** from the queue until all flows are done.
+
+3. **Fewer YAML flows than `--parallel N`**  
+   Example: **3** flow files and `--parallel 5`. The runner starts **3** workers ( **3** Appium sessions), not 5 — **one session per flow**, no empty sessions. Sauce still needs concurrency for **3** simultaneous jobs, not 5.
+
+Sauce Labs enforces **how many tests can run at once** via your plan. If sessions fail to start or queue on the Sauce side, check parallel test limits and regional capacity in the Sauce UI or docs.
+
 ## References
 
 - [Run Maestro Flows on Any Cloud Provider](https://devicelab.dev/blog/run-maestro-flows-any-cloud)
+- [Sauce Labs: `name` (test configuration)](https://docs.saucelabs.com/dev/test-configuration-options/#name)
 - [Sauce Labs: Mobile Appium capabilities](https://docs.saucelabs.com/dev/test-configuration-options/#mobile-appium-capabilities)

--- a/pkg/cli/test.go
+++ b/pkg/cli/test.go
@@ -1823,6 +1823,7 @@ func createAppiumDriver(cfg *RunConfig) (core.Driver, func(), error) {
 		cfg.CloudProvider = p
 		cfg.CloudMeta = make(map[string]string)
 		p.ExtractMeta(driver.SessionID(), driver.SessionCaps(), cfg.CloudMeta)
+		cfg.CloudMeta[cloud.MetaAppiumURL] = strings.TrimSpace(cfg.AppiumURL)
 		logger.Info("Cloud provider detected: %s", p.Name())
 	}
 

--- a/pkg/cloud/provider.go
+++ b/pkg/cloud/provider.go
@@ -7,6 +7,12 @@ package cloud
 
 import "sync"
 
+// Common metadata keys populated by Appium-backed cloud runs.
+const (
+	MetaAppiumURL = "appiumURL"
+	MetaSessionID = "sessionID"
+)
+
 // Provider abstracts cloud device provider operations.
 type Provider interface {
 	// Name returns the human-readable provider name (e.g., "Sauce Labs").

--- a/pkg/cloud/saucelabs.go
+++ b/pkg/cloud/saucelabs.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -62,10 +63,14 @@ func (s *sauceLabs) OnFlowStart(meta map[string]string, flowIdx, totalFlows int,
 		return nil
 	}
 
-	if err := callSauceExecuteScriptContext(appiumURL, sessionID, flowIdx, totalFlows, file); err != nil {
+	yamlForContext := strings.TrimSpace(file)
+	if yamlForContext != "" {
+		yamlForContext = filepath.Base(yamlForContext)
+	}
+	if err := callSauceExecuteScriptContext(appiumURL, sessionID, flowIdx, totalFlows, yamlForContext); err != nil {
 		return fmt.Errorf("call sauce executeScript: %w", err)
 	}
-	logger.Info(`Sauce Labs OnFlowStart: executeScript called with context for [%d/%d] %s`, flowIdx+1, totalFlows, file)
+	logger.Info("Sauce Labs OnFlowStart: executeScript sauce:context (yaml file) for [%d/%d]: %q", flowIdx+1, totalFlows, yamlForContext)
 	return nil
 }
 
@@ -91,17 +96,29 @@ func (s *sauceLabs) ReportResult(appiumURL string, meta map[string]string, resul
 		return err
 	}
 
-	var endpoint string
-	switch meta["type"] {
-	case "rdc":
-		endpoint = strings.TrimSuffix(apiBase, "/") + "/v1/rdc/jobs/" + url.PathEscape(jobID)
-	case "vms":
-		endpoint = strings.TrimSuffix(apiBase, "/") + "/rest/v1/" + url.PathEscape(username) + "/jobs/" + url.PathEscape(jobID)
-	default:
-		return fmt.Errorf("unknown Sauce Labs job type: %s", meta["type"])
+	endpoint, err := sauceJobRESTURL(apiBase, meta["type"], jobID, username)
+	if err != nil {
+		return err
 	}
 
-	return updateJob(endpoint, username, accessKey, result.Passed)
+	// GET same job URL used for RDC ("/v1/rdc/...") or VMS ("/rest/v1/.../jobs/...") and read "name" from the JSON.
+	nameFromJob := ""
+	if n, err := getSauceJobNameFromEndpoint(endpoint, username, accessKey); err != nil {
+		logger.Warn("Sauce Labs ReportResult: job GET (for name): %v", err)
+	} else {
+		nameFromJob = n
+		logger.Info("Sauce Labs ReportResult: name from job GET response: %q", nameFromJob)
+	}
+
+	putName := ""
+	if shouldSetJobNameFromFlowYAML(nameFromJob) {
+		if stem := firstFlowFileStemWithoutYAMLExt(result); stem != "" {
+			putName = stem
+			logger.Info("Sauce Labs ReportResult: will set name on job update to %q (from flow file, replacing empty/default)", putName)
+		}
+	}
+
+	return updateJob(endpoint, username, accessKey, result.Passed, putName)
 }
 
 // apiBaseFromAppiumURL returns the Sauce Labs REST API base URL.
@@ -122,6 +139,21 @@ func apiBaseFromAppiumURL(appiumURL string) (string, error) {
 		return "https://api.us-east-4.saucelabs.com", nil
 	default:
 		return "https://api.us-west-1.saucelabs.com", nil
+	}
+}
+
+// sauceJobRESTURL is the job resource URL used for RDC (GET/PUT) or VMS (GET/PUT).
+func sauceJobRESTURL(apiBase, jobType, jobID, username string) (string, error) {
+	base := strings.TrimSuffix(strings.TrimSpace(apiBase), "/")
+	escapedID := url.PathEscape(jobID)
+	escapedUser := url.PathEscape(username)
+	switch jobType {
+	case "rdc":
+		return base + "/v1/rdc/jobs/" + escapedID, nil
+	case "vms":
+		return base + "/rest/v1/" + escapedUser + "/jobs/" + escapedID, nil
+	default:
+		return "", fmt.Errorf("unknown Sauce Labs job type: %q", jobType)
 	}
 }
 
@@ -193,9 +225,113 @@ func jobUUIDFromSessionCaps(caps map[string]interface{}) string {
 	return ""
 }
 
-// updateJob sends a PUT request with {"passed": bool} to the given endpoint.
-func updateJob(endpoint, username, accessKey string, passed bool) error {
-	payload, err := json.Marshal(map[string]bool{"passed": passed})
+// getSauceJobNameFromEndpoint GETs a job (RDC or VMS path) and returns the "name" field from the JSON.
+func getSauceJobNameFromEndpoint(endpoint, username, accessKey string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return "", fmt.Errorf("build get request: %w", err)
+	}
+	req.SetBasicAuth(username, accessKey)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("http get: %w", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			logger.Debug("sauce labs: close get job body: %v", err)
+		}
+	}()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", fmt.Errorf("read body: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("status %d, body: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return "", fmt.Errorf("parse json: %w", err)
+	}
+	name := nameFromSauceGetJobResponse(parsed)
+	return name, nil
+}
+
+// nameFromSauceGetJobResponse returns the "name" field from Sauce job GET JSON (top-level or common wrappers).
+func nameFromSauceGetJobResponse(m map[string]interface{}) string {
+	if m == nil {
+		return ""
+	}
+	if s := stringField(m, "name"); s != "" {
+		return s
+	}
+	for _, k := range []string{"value", "job", "data"} {
+		if sub, ok := m[k].(map[string]interface{}); ok {
+			if s := stringField(sub, "name"); s != "" {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+func stringField(m map[string]interface{}, key string) string {
+	v, ok := m[key]
+	if !ok || v == nil {
+		return ""
+	}
+	s, ok := v.(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(s)
+}
+
+const defaultSauceAppiumTestName = "Default Appium Test"
+
+// shouldSetJobNameFromFlowYAML is true when the job has no real name in Sauce
+// and we should send "name" from the flow file on the status PUT.
+func shouldSetJobNameFromFlowYAML(nameFromJob string) bool {
+	t := strings.TrimSpace(nameFromJob)
+	return t == "" || t == defaultSauceAppiumTestName
+}
+
+// firstFlowFileStemWithoutYAMLExt returns the first flow's file basename without .yaml or .yml.
+func firstFlowFileStemWithoutYAMLExt(result *TestResult) string {
+	if result == nil {
+		return ""
+	}
+	for _, f := range result.Flows {
+		p := strings.TrimSpace(f.File)
+		if p == "" {
+			continue
+		}
+		base := filepath.Base(p)
+		if ext := filepath.Ext(base); ext != "" {
+			if strings.EqualFold(ext, ".yaml") || strings.EqualFold(ext, ".yml") {
+				return base[:len(base)-len(ext)]
+			}
+			return strings.TrimSuffix(base, ext)
+		}
+		return base
+	}
+	return ""
+}
+
+// updateJob sends a PUT to the job endpoint. If putName is non-empty, the JSON
+// body includes "name" alongside "passed" (RDC and VMS job update).
+func updateJob(endpoint, username, accessKey string, passed bool, putName string) error {
+	reqBody := map[string]interface{}{"passed": passed}
+	if strings.TrimSpace(putName) != "" {
+		reqBody["name"] = strings.TrimSpace(putName)
+	}
+	payload, err := json.Marshal(reqBody)
 	if err != nil {
 		return fmt.Errorf("marshal body: %w", err)
 	}
@@ -221,16 +357,16 @@ func updateJob(endpoint, username, accessKey string, passed bool) error {
 		}
 	}()
 
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("sauce labs api %s: status %d, body: %s", endpoint, resp.StatusCode, strings.TrimSpace(string(body)))
+		return fmt.Errorf("sauce labs api %s: status %d, body: %s", endpoint, resp.StatusCode, strings.TrimSpace(string(respBody)))
 	}
 	return nil
 }
 
 func callSauceExecuteScriptContext(appiumURL, sessionID string, flowIdx, totalFlows int, contextText string) error {
 	endpoint := strings.TrimSuffix(strings.TrimSpace(appiumURL), "/") + "/session/" + url.PathEscape(sessionID) + "/execute/sync"
-	contextMsg := fmt.Sprintf("▶ Start [%d/%d] %s", flowIdx+1, totalFlows, contextText)
+	contextMsg := fmt.Sprintf("- Start [%d/%d] %s", flowIdx+1, totalFlows, contextText)
 	payload := map[string]interface{}{
 		"script": "sauce:context= " + contextMsg,
 		"args":   []interface{}{},
@@ -259,9 +395,9 @@ func callSauceExecuteScriptContext(appiumURL, sessionID string, flowIdx, totalFl
 		}
 	}()
 
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	execReadBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("sauce execute %s: status %d, body: %s", endpoint, resp.StatusCode, strings.TrimSpace(string(body)))
+		return fmt.Errorf("sauce execute %s: status %d, body: %s", endpoint, resp.StatusCode, strings.TrimSpace(string(execReadBody)))
 	}
 	return nil
 }

--- a/pkg/cloud/saucelabs.go
+++ b/pkg/cloud/saucelabs.go
@@ -33,13 +33,19 @@ type sauceLabs struct{}
 func (s *sauceLabs) Name() string { return "Sauce Labs" }
 
 func (s *sauceLabs) ExtractMeta(sessionID string, caps map[string]interface{}, meta map[string]string) {
-	meta[MetaSessionID] = strings.TrimSpace(sessionID)
+	sid := strings.TrimSpace(sessionID)
+	meta[MetaSessionID] = sid
 	if capsDeviceNameIndicatesEmuSim(caps) {
 		meta["type"] = "vms"
-		meta["jobID"] = sessionID
+		meta["jobID"] = sid
 	} else {
 		meta["type"] = "rdc"
 		meta["jobID"] = jobUUIDFromSessionCaps(caps)
+		if meta["jobID"] == "" {
+			logger.Info("*** Sauce Labs ExtractMeta: no jobUuid in session caps; using session id as VMS job id")
+			meta["type"] = "vms"
+			meta["jobID"] = sid
+		}
 	}
 	logger.Info("*** Sauce Labs ExtractMeta: type=%q jobID=%q", meta["type"], meta["jobID"])
 }
@@ -368,7 +374,7 @@ func updateJob(endpoint, username, accessKey string, passed bool, putName string
 
 func callSauceExecuteScriptContext(appiumURL, sessionID string, flowIdx, totalFlows int, contextText string) error {
 	endpoint := strings.TrimSuffix(strings.TrimSpace(appiumURL), "/") + "/session/" + url.PathEscape(sessionID) + "/execute/sync"
-	contextMsg := fmt.Sprintf("- Start [%d/%d] %s", flowIdx+1, totalFlows, contextText)
+	contextMsg := fmt.Sprintf("- Starting Maestro test flow: %s", contextText)
 	payload := map[string]interface{}{
 		"script": "sauce:context= " + contextMsg,
 		"args":   []interface{}{},

--- a/pkg/cloud/saucelabs.go
+++ b/pkg/cloud/saucelabs.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -31,6 +32,7 @@ type sauceLabs struct{}
 func (s *sauceLabs) Name() string { return "Sauce Labs" }
 
 func (s *sauceLabs) ExtractMeta(sessionID string, caps map[string]interface{}, meta map[string]string) {
+	meta[MetaSessionID] = strings.TrimSpace(sessionID)
 	if capsDeviceNameIndicatesEmuSim(caps) {
 		meta["type"] = "vms"
 		meta["jobID"] = sessionID
@@ -43,12 +45,27 @@ func (s *sauceLabs) ExtractMeta(sessionID string, caps map[string]interface{}, m
 // OnRunStart is a no-op — Sauce Labs jobs are created server-side by the
 // Appium session, so there's nothing to signal at run start.
 func (s *sauceLabs) OnRunStart(meta map[string]string, totalFlows int) error {
+	logger.Info("*** Sauce Labs OnRunStart called: totalFlows=%d", totalFlows)
+	logSauceMeta("OnRunStart", meta)
 	return nil
 }
 
-// OnFlowStart is a no-op — Sauce's dashboard renders test cases from the
-// final result payload, so there's no per-flow API to ping at flow start.
+// OnFlowStart calls Sauce executeScript via WebDriver execute/sync using
+// appiumURL + sessionID from meta.
 func (s *sauceLabs) OnFlowStart(meta map[string]string, flowIdx, totalFlows int, name, file string) error {
+	logger.Info("*** Sauce Labs OnFlowStart called: flowIdx=%d totalFlows=%d name=%q file=%q", flowIdx, totalFlows, name, file)
+	logSauceMeta("OnFlowStart", meta)
+	appiumURL := strings.TrimSpace(meta[MetaAppiumURL])
+	sessionID := strings.TrimSpace(meta[MetaSessionID])
+	if appiumURL == "" || sessionID == "" {
+		logger.Warn("Sauce Labs OnFlowStart: missing appiumURL/sessionID, skip Sauce executeScript call")
+		return nil
+	}
+
+	if err := callSauceExecuteScriptContext(appiumURL, sessionID, flowIdx, totalFlows, file); err != nil {
+		return fmt.Errorf("call sauce executeScript: %w", err)
+	}
+	logger.Info(`Sauce Labs OnFlowStart: executeScript called with context for [%d/%d] %s`, flowIdx+1, totalFlows, file)
 	return nil
 }
 
@@ -209,4 +226,58 @@ func updateJob(endpoint, username, accessKey string, passed bool) error {
 		return fmt.Errorf("sauce labs api %s: status %d, body: %s", endpoint, resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 	return nil
+}
+
+func callSauceExecuteScriptContext(appiumURL, sessionID string, flowIdx, totalFlows int, contextText string) error {
+	endpoint := strings.TrimSuffix(strings.TrimSpace(appiumURL), "/") + "/session/" + url.PathEscape(sessionID) + "/execute/sync"
+	contextMsg := fmt.Sprintf("▶ Start [%d/%d] %s", flowIdx+1, totalFlows, contextText)
+	payload := map[string]interface{}{
+		"script": "sauce:context= " + contextMsg,
+		"args":   []interface{}{},
+	}
+	bodyBytes, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal execute payload: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return fmt.Errorf("build execute request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("http post execute: %w", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			logger.Debug("sauce labs: close execute response body: %v", err)
+		}
+	}()
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("sauce execute %s: status %d, body: %s", endpoint, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return nil
+}
+
+
+func logSauceMeta(hook string, meta map[string]string) {
+	if len(meta) == 0 {
+		logger.Info("Sauce Labs %s meta: <empty>", hook)
+		return
+	}
+	keys := make([]string, 0, len(meta))
+	for k := range meta {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		logger.Info("Sauce Labs %s meta[%s]=%q", hook, k, meta[k])
+	}
 }

--- a/pkg/cloud/saucelabs.go
+++ b/pkg/cloud/saucelabs.go
@@ -41,6 +41,7 @@ func (s *sauceLabs) ExtractMeta(sessionID string, caps map[string]interface{}, m
 		meta["type"] = "rdc"
 		meta["jobID"] = jobUUIDFromSessionCaps(caps)
 	}
+	logger.Info("*** Sauce Labs ExtractMeta: type=%q jobID=%q", meta["type"], meta["jobID"])
 }
 
 // OnRunStart is a no-op — Sauce Labs jobs are created server-side by the
@@ -82,6 +83,7 @@ func (s *sauceLabs) OnFlowEnd(meta map[string]string, result *FlowResult) error 
 
 func (s *sauceLabs) ReportResult(appiumURL string, meta map[string]string, result *TestResult) error {
 	jobID := strings.TrimSpace(meta["jobID"])
+	logger.Info("*** Sauce Labs ReportResult: starting with jobID=%q result=%+v", jobID, result)
 	if jobID == "" {
 		return fmt.Errorf("no job ID available")
 	}


### PR DESCRIPTION
## Summary

Improves the Sauce Labs cloud provider so jobs are easier to identify in the Sauce UI and so virtual / edge cases still resolve the correct job for REST updates. The runner now sends sauce:context at each flow start (YAML basename + progress), refreshes the job name from the Sauce API when updating pass/fail, and falls back to the Maestro flow filename when Sauce still shows an empty or default name. ExtractMeta also treats missing jobUuid (non–emu/sim caps) as VMS and uses the WebDriver session id as the job id, matching Sauce’s virtual-device REST paths.

## Type of Change

- [X ] Bug fix (non-breaking change that fixes an issue)
- [ X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

*ExtractMeta: Store trimmed session id in MetaSessionID; use it for VMS jobID; if RDC caps have no jobUuid, log and fall back to type=vms + session id for REST.
*OnFlowStart: POST /session/{id}/execute/sync with sauce:context= - Start [i/n] <flow-basename> so Sauce shows per-flow context.
*ReportResult: GET job (RDC/VMS) to read current name; on final PUT, include optional name from the first flow file stem when Sauce’s name is empty or Default Appium Test.
*Tests: TestExtractMeta_RealDeviceCaps_FallbackWhenJobUUIDEmpty; updateJob test calls updated for the putName parameter.

## Related Issues

Fixes #(issue number)

## Testing

- [ ] Tests pass locally (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Added tests for new functionality
- [ X] Tested manually with sample flows

## Checklist

- [X ] Code follows project style guidelines
- [ X] Self-reviewed the code
- [ X] Added/updated documentation as needed
- [ X] No breaking changes (or documented if breaking)
- [ ] CHANGELOG.md updated (for notable changes)

## Additional Notes

Any additional context or screenshots.
* Job naming: Flow stem is only sent when the GET shows no meaningful name or Sauce’s default test name; otherwise the existing Sauce/sauce:options.name name is preserved.
* sauce:context: Uses the flow file basename (not full path); requires MetaAppiumURL and MetaSessionID in cloud meta (set by the CLI after session creation).