### PR TITLE
Web: tapOn dispatches into iframes / shadow roots via Playwright-pattern coord translation + hit-target verify

### DIFF
--- a/pkg/driver/browser/cdp/commands.go
+++ b/pkg/driver/browser/cdp/commands.go
@@ -43,6 +43,19 @@ func (d *Driver) tapOn(step *flow.TapOnStep) *core.CommandResult {
 		return successResult(fmt.Sprintf("Selected option %s", step.Selector.DescribeQuoted()), info)
 	}
 
+	// Iframe / shadow-root branch: when the element lives inside an iframe,
+	// Rod's Click() uses iframe-LOCAL coordinates while CDP Input.dispatchMouseEvent
+	// operates in TOP-FRAME viewport coordinates — clicks land at the wrong place
+	// and report success silently. Route these through the coord-translated
+	// dispatch path which also runs Playwright-style hit-target verification.
+	// Top-frame elements (including those inside top-frame shadow roots) keep
+	// the existing path — getBoundingClientRect() is already in top-frame
+	// coords for them, so Rod's Click() is correct. (Issues #71/#72 acting layer.)
+	inIframe, _ := elem.Eval(`() => window.__maestro._isInIframe(this)`)
+	if inIframe != nil && inIframe.Value.Bool() {
+		return d.tapOnCrossRoot(elem, info, step)
+	}
+
 	if err := elem.Click(proto.InputMouseButtonLeft, 1); err != nil {
 		// Fallback: use JS click (handles elements that can't receive CDP input events)
 		if _, jsErr := elem.Eval(`() => this.click()`); jsErr != nil {
@@ -51,6 +64,118 @@ func (d *Driver) tapOn(step *flow.TapOnStep) *core.CommandResult {
 	}
 
 	return successResult(fmt.Sprintf("Tapped on %s", step.Selector.DescribeQuoted()), info)
+}
+
+// tapOnCrossRoot dispatches a tap against an element nested inside an iframe
+// (or iframe + open shadow root). Translates the element's coordinate from
+// iframe-local to top-frame viewport coordinates, runs Playwright-style
+// hit-target verification before and after dispatch, and uses page-level
+// Mouse to send a trusted Input.dispatchMouseEvent at the translated point.
+//
+// Ports microsoft/playwright `_checkFrameIsHitTarget` (server/dom.ts) and
+// `setupHitTargetInterceptor` (injected/injectedScript.ts) into the maestro
+// CDP driver. The coord-translation walk is in jshelper.js
+// (`topFrameClickPoint`); pre-flight + interceptor lives in
+// `setupHitTargetInterceptor`. (Issues #71/#72 acting layer.)
+func (d *Driver) tapOnCrossRoot(elem *rod.Element, info *core.ElementInfo, step *flow.TapOnStep) *core.CommandResult {
+	desc := step.Selector.DescribeQuoted()
+
+	// Step 1: compute top-frame click point. The JS walks up the frame chain,
+	// adding each iframe's box.left/top + content-area inset (border+padding)
+	// at every level, ending with a coord in the top-frame viewport.
+	// Throws on transformed-iframe ancestors (Playwright bails on transforms
+	// rather than computing through DOMMatrix; we follow that decision).
+	ptRes, err := elem.Eval(`() => {
+		var p = window.__maestro.topFrameClickPoint(this);
+		return [p.x, p.y];
+	}`)
+	if err != nil {
+		return errorResult(err, fmt.Sprintf("Cross-root click setup failed for %s: %v", desc, err))
+	}
+	arr := ptRes.Value.Arr()
+	if len(arr) != 2 {
+		return errorResult(
+			fmt.Errorf("topFrameClickPoint returned %d values", len(arr)),
+			fmt.Sprintf("Failed to compute cross-root click point for %s", desc))
+	}
+	x := arr[0].Num()
+	y := arr[1].Num()
+
+	// Step 2: pre-flight expectHitTarget + install trusted-event interceptor.
+	// Pre-flight runs elementsFromPoint per shadow root and walks slot/host
+	// chain to verify the click point would land on our target. If something
+	// occludes (modal overlay, hidden iframe, etc.), we get back an
+	// {error: hitTargetDescription} and bail before dispatch.
+	setupRes, err := elem.Eval(
+		`(x, y) => window.__maestro.setupHitTargetInterceptor(this, {x: x, y: y})`,
+		x, y)
+	if err != nil {
+		return errorResult(err, fmt.Sprintf("Failed to set up hit-target interceptor for %s", desc))
+	}
+	if setupRes.Value.Has("error") {
+		errMsg := setupRes.Value.Get("error").Str()
+		return errorResult(
+			fmt.Errorf("hit-target pre-flight: %s blocks %s", errMsg, desc),
+			fmt.Sprintf("Click on %s blocked by overlay (%s)", desc, errMsg))
+	}
+	if !setupRes.Value.Has("token") {
+		return errorResult(
+			fmt.Errorf("interceptor returned no token"),
+			fmt.Sprintf("Failed to set up hit-target interceptor for %s", desc))
+	}
+	token := setupRes.Value.Get("token").Int()
+
+	// Defensive cleanup. pollHitTargetResult also frees the token on capture,
+	// but if we error out before polling, this prevents a leaked listener.
+	defer func() {
+		_, _ = d.page.Eval(`(t) => window.__maestro.disposeHitTargetInterceptor(t)`, token)
+	}()
+
+	// Step 3: dispatch via top-frame mouse. Produces a trusted
+	// pointerdown/mousedown/click sequence; the JS interceptor captures the
+	// actual clientX/Y at event-fire time and runs expectHitTarget against
+	// that point. We do NOT use elem.Click() here — that's the buggy path
+	// for cross-root elements.
+	mouse := d.page.Mouse
+	if err := mouse.MoveTo(proto.NewPoint(x, y)); err != nil {
+		return errorResult(err, fmt.Sprintf("Failed to move mouse for %s", desc))
+	}
+	if err := mouse.Click(proto.InputMouseButtonLeft, 1); err != nil {
+		return errorResult(err, fmt.Sprintf("Failed to dispatch click for %s", desc))
+	}
+
+	// Step 4: poll for verify result. Chromium delivers trusted events
+	// synchronously during Mouse.Click, so the first poll is usually
+	// decisive. Brief retry window absorbs scheduler jitter on slower
+	// machines / CI.
+	for i := 0; i < 5; i++ {
+		pollRes, pollErr := d.page.Eval(`(t) => window.__maestro.pollHitTargetResult(t)`, token)
+		if pollErr != nil {
+			return errorResult(pollErr, fmt.Sprintf("Failed to poll hit-target result for %s", desc))
+		}
+		v := pollRes.Value
+		if v.Has("hitTargetDescription") {
+			hd := v.Get("hitTargetDescription").Str()
+			return errorResult(
+				fmt.Errorf("click did not reach %s — landed on %s", desc, hd),
+				fmt.Sprintf("Click on %s did not reach the target (landed on %s)", desc, hd))
+		}
+		switch v.Str() {
+		case "pending":
+			time.Sleep(20 * time.Millisecond)
+			continue
+		case "done":
+			return successResult(fmt.Sprintf("Tapped on %s", desc), info)
+		default:
+			// Unrecognized payload — be permissive (don't manufacture
+			// failures from unknown shapes), but the success path still
+			// returns the standard ok result.
+			return successResult(fmt.Sprintf("Tapped on %s", desc), info)
+		}
+	}
+	return errorResult(
+		fmt.Errorf("hit-target verify did not capture trusted event within timeout"),
+		fmt.Sprintf("Click on %s dispatched but verification timed out", desc))
 }
 
 // doubleTapOn double-clicks an element.

--- a/pkg/driver/browser/cdp/commands_iframe_test.go
+++ b/pkg/driver/browser/cdp/commands_iframe_test.go
@@ -1,0 +1,286 @@
+package cdp
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/devicelab-dev/maestro-runner/pkg/flow"
+)
+
+// Tests for iframe / shadow-root coordinate-translated tapOn.
+//
+// Covers:
+//   A: top-frame button — uses the existing Rod Click() path; verifies the
+//      cross-root branch does not regress simple cases.
+//   B: iframe-nested button (no shadow) — exercises topFrameClickPoint coord
+//      translation through a single iframe boundary.
+//   C: iframe + open shadow root — mirrors the repro from issues #71/#72
+//      acting layer (Flutter-Web-shaped accessibility tree inside an iframe).
+//   D: iframe-nested button occluded by a same-frame overlay — exercises
+//      Playwright-pattern hit-target pre-flight rejection.
+//   E: iframe inside a CSS-transformed wrapper — exercises the transform
+//      bail (Playwright bails on transforms; we follow that decision).
+//
+// Issues #71/#72 acting layer.
+
+// iframeTopFramePage returns a top-frame page with a single button. Used by
+// case A.
+func iframeTopFramePage() string {
+	return `<!DOCTYPE html>
+<html><body>
+<button id="b" onclick="document.title='clicked-top'">DoIt</button>
+</body></html>`
+}
+
+// iframePageWithButton returns a top-frame page that hosts an iframe (via
+// srcdoc) containing a plain <button>. The button's click handler updates
+// document.title in the IFRAME so the test can assert the click landed.
+// The handler is attached via addEventListener inside a <script> tag rather
+// than an inline onclick attribute — onclick value strings get tangled with
+// srcdoc's own attribute quoting after one round of HTML entity decoding.
+// Used by case B.
+func iframePageWithButton() string {
+	return `<!DOCTYPE html>
+<html><body>
+<h1>HEADER</h1>
+<iframe id="f" title="inner" srcdoc='<!DOCTYPE html><html><body style="margin:0;padding:24px">
+<button id="b">DoIt</button>
+<script>
+document.getElementById("b").addEventListener("click", function() { document.title = "clicked-iframe"; });
+</script>
+</body></html>'></iframe>
+</body></html>`
+}
+
+// iframePageWithShadowDOM returns a top-frame page that hosts an iframe
+// whose body mounts an open shadow root containing a button. Mirrors the
+// hosted repro page used to reproduce #71/#72 acting-layer bugs.
+//
+// Quoting is delicate: srcdoc decodes HTML entities once, so the JS inside
+// the script tag arrives unencoded. Use template literals (backticks) for
+// CSS-selector strings rather than nested double-quoted strings, and use
+// `getAttribute("role") === ...` checks rather than complex selectors so
+// the script source remains valid after one round of entity decoding.
+// Used by case C.
+func iframePageWithShadowDOM() string {
+	return `<!DOCTYPE html>
+<html><body>
+<h1>HEADER</h1>
+<iframe id="f" title="inner" srcdoc='<!DOCTYPE html><html><body style="margin:0">
+<flutter-view><flt-glass-pane id="g"></flt-glass-pane></flutter-view>
+<template id="t">
+<style>
+flt-semantics-host, flt-semantics, flt-semantics-container { display: block; }
+flt-semantics[role="dialog"] { position: absolute; left: 50%; top: 40%; transform: translate(-50%, -50%); width: 200px; padding: 24px; background: #fff; border: 1px solid #ddd; }
+flt-semantics[role="button"] { display: inline-block; margin-top: 16px; padding: 8px 16px; background: #1976d2; color: #fff; cursor: pointer; }
+</style>
+<flt-semantics-host>
+<flt-semantics role="dialog" aria-label="Welcome dialog">
+<flt-semantics-container>
+<flt-semantics aria-label="DIALOG_BODY_TEXT">DIALOG_BODY_TEXT</flt-semantics>
+<flt-semantics role="button" aria-label="Close" tabindex="0">Close</flt-semantics>
+</flt-semantics-container>
+</flt-semantics>
+</flt-semantics-host>
+</template>
+<script>
+var host = document.getElementById("g");
+var sr = host.attachShadow({ mode: "open" });
+sr.appendChild(document.getElementById("t").content.cloneNode(true));
+var all = sr.querySelectorAll("flt-semantics");
+var closeBtn = null, dialog = null;
+for (var i = 0; i < all.length; i++) {
+  var role = all[i].getAttribute("role");
+  if (role === "button") closeBtn = all[i];
+  if (role === "dialog") dialog = all[i];
+}
+closeBtn.addEventListener("click", function() {
+  if (dialog) dialog.remove();
+  document.title = "dialog-closed";
+});
+</script>
+</body></html>'></iframe>
+</body></html>`
+}
+
+// iframePageWithOccludedButton returns a top-frame page with an iframe whose
+// body has a button covered by a fixed-position overlay div sitting on top.
+// Used by case D — pre-flight expectHitTarget should reject before dispatch.
+func iframePageWithOccludedButton() string {
+	return `<!DOCTYPE html>
+<html><body>
+<h1>HEADER</h1>
+<iframe id="f" title="inner" srcdoc='<!DOCTYPE html><html><body style="margin:0;padding:24px;position:relative">
+<button id="b" style="position:absolute;left:24px;top:24px;width:120px;height:40px">DoIt</button>
+<div id="overlay" style="position:absolute;left:0;top:0;width:100%;height:100%;background:rgba(0,0,0,0.5);z-index:10"></div>
+<script>
+document.getElementById("b").addEventListener("click", function() { document.title = "clicked-button"; });
+</script>
+</body></html>'></iframe>
+</body></html>`
+}
+
+// iframePageWithTransform returns a top-frame page that wraps the iframe in
+// a translated container. Used by case E — describeIFrameStyle bails with
+// 'transformed' which surfaces as a clear error from tapOnCrossRoot.
+func iframePageWithTransform() string {
+	return `<!DOCTYPE html>
+<html><body>
+<h1>HEADER</h1>
+<div style="transform: translateX(20px)">
+<iframe id="f" title="inner" srcdoc='<!DOCTYPE html><html><body style="margin:0;padding:24px">
+<button id="b">DoIt</button>
+<script>
+document.getElementById("b").addEventListener("click", function() { document.title = "clicked-transformed"; });
+</script>
+</body></html>'></iframe>
+</div>
+</body></html>`
+}
+
+// newIframeTestServer wraps a single HTML string in an httptest server.
+func newIframeTestServer(html string) *httptest.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, html)
+	})
+	return httptest.NewServer(mux)
+}
+
+// pageTitle reads document.title from the driver's current page.
+func pageTitle(t *testing.T, d *Driver) string {
+	t.Helper()
+	res, err := d.page.Eval(`() => document.title`)
+	if err != nil {
+		t.Fatalf("page eval document.title: %v", err)
+	}
+	return res.Value.Str()
+}
+
+// iframeTitle reads document.title from inside the iframe whose CSS id is
+// "f". Click handlers in the iframe update the iframe's title, not the top
+// frame's.
+func iframeTitle(t *testing.T, d *Driver) string {
+	t.Helper()
+	res, err := d.page.Eval(`() => {
+		var f = document.getElementById('f');
+		return (f && f.contentDocument && f.contentDocument.title) || '';
+	}`)
+	if err != nil {
+		t.Fatalf("page eval iframe title: %v", err)
+	}
+	return res.Value.Str()
+}
+
+// TestTapOnCrossRoot_TopFrame (case A): top-frame button must still work,
+// using the existing Rod Click() path, not the new cross-root path.
+func TestTapOnCrossRoot_TopFrame(t *testing.T) {
+	ts := newIframeTestServer(iframeTopFramePage())
+	defer ts.Close()
+	d := newTestDriver(t, ts.URL)
+	defer d.Close()
+
+	res := d.Execute(&flow.TapOnStep{Selector: flow.Selector{Text: "DoIt"}})
+	if !res.Success {
+		t.Fatalf("tapOn DoIt failed: %s", res.Message)
+	}
+	if got := pageTitle(t, d); got != "clicked-top" {
+		t.Errorf("expected top-frame title 'clicked-top', got %q", got)
+	}
+}
+
+// TestTapOnCrossRoot_Iframe (case B): button inside a same-origin iframe
+// (no shadow). Verifies coord translation through a single iframe boundary.
+func TestTapOnCrossRoot_Iframe(t *testing.T) {
+	ts := newIframeTestServer(iframePageWithButton())
+	defer ts.Close()
+	d := newTestDriver(t, ts.URL)
+	defer d.Close()
+
+	res := d.Execute(&flow.TapOnStep{Selector: flow.Selector{Text: "DoIt"}})
+	if !res.Success {
+		t.Fatalf("tapOn DoIt (iframe) failed: %s", res.Message)
+	}
+	if got := iframeTitle(t, d); got != "clicked-iframe" {
+		t.Errorf("expected iframe title 'clicked-iframe', got %q", got)
+	}
+}
+
+// TestTapOnCrossRoot_IframeShadow (case C): button inside an open shadow
+// root inside an iframe — the repro shape from issues #71/#72 acting layer.
+func TestTapOnCrossRoot_IframeShadow(t *testing.T) {
+	ts := newIframeTestServer(iframePageWithShadowDOM())
+	defer ts.Close()
+	d := newTestDriver(t, ts.URL)
+	defer d.Close()
+
+	// Sanity: dialog body is visible before tap.
+	res := d.Execute(&flow.AssertVisibleStep{
+		Selector: flow.Selector{Text: "DIALOG_BODY_TEXT"},
+	})
+	if !res.Success {
+		t.Fatalf("dialog body should be visible before tap: %s", res.Message)
+	}
+
+	// Tap Close button inside the iframe + shadow.
+	res = d.Execute(&flow.TapOnStep{Selector: flow.Selector{Text: "Close"}})
+	if !res.Success {
+		t.Fatalf("tapOn Close (iframe+shadow) failed: %s", res.Message)
+	}
+
+	// Verify the iframe-side click handler ran.
+	if got := iframeTitle(t, d); got != "dialog-closed" {
+		t.Errorf("expected iframe title 'dialog-closed', got %q", got)
+	}
+}
+
+// TestTapOnCrossRoot_Occluded (case D): button covered by a same-frame
+// overlay. Pre-flight expectHitTarget should reject and tapOn should
+// surface the occlusion as an error rather than silently dispatching.
+func TestTapOnCrossRoot_Occluded(t *testing.T) {
+	ts := newIframeTestServer(iframePageWithOccludedButton())
+	defer ts.Close()
+	d := newTestDriver(t, ts.URL)
+	defer d.Close()
+
+	res := d.Execute(&flow.TapOnStep{Selector: flow.Selector{Text: "DoIt"}})
+	if res.Success {
+		t.Fatalf("tapOn occluded button should fail; got success message %q", res.Message)
+	}
+	// Be lenient about the exact phrasing — just require that the error
+	// message mentions occlusion / blocked / overlay so future wording
+	// tweaks don't break the test.
+	low := strings.ToLower(res.Message)
+	if !strings.Contains(low, "block") && !strings.Contains(low, "overlay") &&
+		!strings.Contains(low, "reach") && !strings.Contains(low, "hit") {
+		t.Errorf("expected occlusion-shaped error, got %q", res.Message)
+	}
+	// And the click handler should NOT have run.
+	if got := iframeTitle(t, d); got == "clicked-button" {
+		t.Errorf("click handler ran despite occlusion (title=%q)", got)
+	}
+}
+
+// TestTapOnCrossRoot_Transformed (case E): iframe wrapped in a CSS transform.
+// describeIFrameStyle bails with 'transformed' (Playwright pattern); the
+// resulting tapOnCrossRoot path returns a clear error rather than computing
+// through DOMMatrix.
+func TestTapOnCrossRoot_Transformed(t *testing.T) {
+	ts := newIframeTestServer(iframePageWithTransform())
+	defer ts.Close()
+	d := newTestDriver(t, ts.URL)
+	defer d.Close()
+
+	res := d.Execute(&flow.TapOnStep{Selector: flow.Selector{Text: "DoIt"}})
+	if res.Success {
+		t.Fatalf("tapOn through transformed iframe should fail; got success %q", res.Message)
+	}
+	low := strings.ToLower(res.Message)
+	if !strings.Contains(low, "transform") && !strings.Contains(low, "iframe coord") {
+		t.Errorf("expected transformed-iframe error, got %q", res.Message)
+	}
+}

--- a/pkg/driver/browser/cdp/finder.go
+++ b/pkg/driver/browser/cdp/finder.go
@@ -510,6 +510,15 @@ func (d *Driver) findByAXTree(text, role string, sel flow.Selector) (*rod.Elemen
 }
 
 // findBySearch uses Rod's page.Search() which handles Shadow DOM via DOMPerformSearch.
+//
+// Reject IFRAME results: CDP DOM.performSearch matches against the iframe
+// element's serialized attributes, including srcdoc — for an iframe whose
+// srcdoc HTML happens to contain the search text, the iframe element itself
+// is returned. That is essentially never what the caller wants (the caller
+// is looking for a tappable text element, not the iframe wrapper). Falling
+// through here lets the cascade reach the JS findByText path, which walks
+// _collectRoots() into the iframe document and shadow DOM and returns the
+// actual visible match. (Issues #71/#72 acting layer.)
 func (d *Driver) findBySearch(text string, sel flow.Selector) (*rod.Element, *core.ElementInfo, error) {
 	p := d.page.Timeout(2 * time.Second)
 	res, err := p.Search(text)
@@ -523,6 +532,10 @@ func (d *Driver) findBySearch(text string, sel flow.Selector) (*rod.Element, *co
 	}
 
 	elem := res.First
+	if tag, _ := elem.Eval(`() => this.tagName`); tag != nil &&
+		(tag.Value.Str() == "IFRAME" || tag.Value.Str() == "FRAME") {
+		return nil, nil, fmt.Errorf("search returned iframe element (likely srcdoc text match) — falling through to JS findByText")
+	}
 	if !d.matchesStateFilters(elem, sel) {
 		return nil, nil, fmt.Errorf("search found element but state filters don't match")
 	}

--- a/pkg/driver/browser/cdp/jshelper.js
+++ b/pkg/driver/browser/cdp/jshelper.js
@@ -402,5 +402,300 @@ window.__maestro = {
       }
       requestAnimationFrame(check);
     });
+  },
+
+  // ─── Iframe / shadow-root click coordinate translation + hit-target verify ───
+  //
+  // Ports Playwright's `_checkFrameIsHitTarget` walk and `setupHitTargetInterceptor`
+  // (microsoft/playwright `packages/playwright-core/src/server/dom.ts` and
+  // `packages/injected/src/injectedScript.ts`) so that taps on elements nested
+  // inside iframes (or iframe + open shadow root) dispatch at the correct
+  // top-frame viewport coordinates and verify post-dispatch that the click
+  // actually reached the target. (Issues #71/#72 acting layer.)
+  //
+  // Why a new path: Rod's Element.Click() uses getBoundingClientRect() which
+  // returns iframe-LOCAL coordinates for elements inside an iframe. CDP
+  // Input.dispatchMouseEvent operates in TOP-FRAME viewport coordinates.
+  // Mismatch → click lands at the wrong place, reports success silently.
+
+  // _parentElementOrShadowHost: walk one step up — through parent element or
+  // through shadow-root host boundary. Mirrors Playwright domUtils helper of
+  // the same name.
+  _parentElementOrShadowHost: function(el) {
+    if (!el) return null;
+    if (el.parentElement) return el.parentElement;
+    var root = el.getRootNode && el.getRootNode();
+    // 11 = DOCUMENT_FRAGMENT_NODE; ShadowRoot is the only fragment with .host
+    if (root && root.nodeType === 11 && root.host) return root.host;
+    return null;
+  },
+
+  // _isInIframe: cheap check used by Go to decide whether to use the new
+  // coord-translated dispatch path. True iff the element's owner document has
+  // a non-null frameElement (i.e. it lives inside an iframe at any depth).
+  // Top-frame elements (including those inside top-frame shadow roots) keep
+  // the existing Rod Click() path — getBoundingClientRect() is already in the
+  // top-frame viewport for them.
+  _isInIframe: function(el) {
+    if (!el) return false;
+    var doc = el.ownerDocument;
+    if (!doc || !doc.defaultView) return false;
+    try { return !!doc.defaultView.frameElement; } catch (e) { return false; }
+  },
+
+  // _describeIFrameStyle: verbatim port of Playwright's `describeIFrameStyle`.
+  // Returns the iframe's content-area inset (border + padding) within the
+  // iframe element box, or 'transformed' if the iframe (or any ancestor) has
+  // a CSS transform — Playwright bails on transforms rather than computing
+  // through DOMMatrix; we follow that decision so a transformed-iframe page
+  // surfaces a clear error instead of a subtly-wrong click.
+  _describeIFrameStyle: function(iframe) {
+    if (!iframe.ownerDocument || !iframe.ownerDocument.defaultView)
+      return 'error:notconnected';
+    var defaultView = iframe.ownerDocument.defaultView;
+    for (var e = iframe; e; e = this._parentElementOrShadowHost(e)) {
+      try {
+        if (defaultView.getComputedStyle(e).transform !== 'none') return 'transformed';
+      } catch (err) { /* getComputedStyle on detached element throws */ }
+    }
+    var s = defaultView.getComputedStyle(iframe);
+    return {
+      left: parseInt(s.borderLeftWidth || '', 10) + parseInt(s.paddingLeft || '', 10),
+      top:  parseInt(s.borderTopWidth  || '', 10) + parseInt(s.paddingTop  || '', 10)
+    };
+  },
+
+  // topFrameClickPoint: translate an element's center point from iframe-local
+  // viewport coordinates into top-frame viewport coordinates. Walks up the
+  // frame chain; at each level adds the iframe element's box (its position in
+  // the parent document) plus the iframe's content-area inset.
+  //
+  // Inverse direction of Playwright's `_checkFrameIsHitTarget` (which starts
+  // with top-frame coords and SUBTRACTS to find frame-local coords for
+  // occlusion checks at each level). We start frame-local and ADD.
+  //
+  // Throws on transformed-iframe ancestors (see _describeIFrameStyle).
+  topFrameClickPoint: function(el) {
+    var r = el.getBoundingClientRect();
+    var pt = { x: r.left + r.width / 2, y: r.top + r.height / 2 };
+    var doc = el.ownerDocument;
+    while (doc && doc.defaultView) {
+      var iframe;
+      try { iframe = doc.defaultView.frameElement; } catch (e) { break; }
+      if (!iframe) break;
+      var style = this._describeIFrameStyle(iframe);
+      if (typeof style === 'string') {
+        throw new Error('iframe coord translation: ' + style + ' iframe ancestor');
+      }
+      var box = iframe.getBoundingClientRect();
+      pt.x += box.left + style.left;
+      pt.y += box.top + style.top;
+      doc = iframe.ownerDocument;
+    }
+    return pt;
+  },
+
+  // _previewNode: short string description of a node, used inside
+  // hitTargetDescription for actionable error messages. Best-effort, never
+  // throws.
+  _previewNode: function(node) {
+    if (!node) return '<none>';
+    try {
+      var tag = (node.tagName || node.nodeName || '').toLowerCase();
+      var id = node.id ? '#' + node.id : '';
+      var cls = '';
+      if (node.classList && node.classList.length) {
+        cls = '.' + Array.prototype.slice.call(node.classList).slice(0, 2).join('.');
+      }
+      var text = '';
+      if (node.textContent) {
+        var t = node.textContent.trim().replace(/\s+/g, ' ');
+        if (t) text = ' "' + (t.length > 30 ? t.slice(0, 30) + '…' : t) + '"';
+      }
+      return '<' + tag + id + cls + '>' + text;
+    } catch (e) { return '<node>'; }
+  },
+
+  // expectHitTarget: verbatim port of Playwright's `expectHitTarget` from
+  // injectedScript.ts. Walks shadow-root boundaries via elementsFromPoint per
+  // root (document.elementFromPoint does NOT pierce shadow boundaries — only
+  // sees the host). Returns 'done' if the click point would land on the
+  // target (or one of its descendants reachable through slot/host chain), or
+  // { hitTargetDescription } if something is in the way.
+  expectHitTarget: function(hitPoint, targetElement) {
+    var roots = [];
+    var parentElement = targetElement;
+    while (parentElement) {
+      var root = parentElement.getRootNode && parentElement.getRootNode();
+      if (!root) break;
+      roots.push(root);
+      if (root.nodeType === 9) break; // 9 = DOCUMENT_NODE; reached top
+      parentElement = root.host; // ShadowRoot.host
+    }
+    var hitElement;
+    for (var index = roots.length - 1; index >= 0; index--) {
+      var r = roots[index];
+      var elements;
+      var single;
+      try {
+        elements = r.elementsFromPoint(hitPoint.x, hitPoint.y);
+        single = r.elementFromPoint(hitPoint.x, hitPoint.y);
+      } catch (e) { break; }
+      if (single && elements && elements[0] &&
+          this._parentElementOrShadowHost(single) === elements[0]) {
+        try {
+          var st = window.getComputedStyle(single);
+          if (st && st.display === 'contents') elements.unshift(single);
+        } catch (e) {}
+      }
+      if (elements && elements[0] && elements[0].shadowRoot === r &&
+          elements[1] === single) {
+        elements.shift();
+      }
+      var innerElement = elements && elements[0];
+      if (!innerElement) break;
+      hitElement = innerElement;
+      // If we're not at the deepest root yet, the hit element should be the
+      // shadow host that opens the next root down. If it isn't, occlusion at
+      // an outer level — stop walking deeper.
+      if (index && innerElement !== (roots[index - 1] && roots[index - 1].host)) break;
+    }
+    var hitParents = [];
+    while (hitElement && hitElement !== targetElement) {
+      hitParents.push(hitElement);
+      hitElement = hitElement.assignedSlot || this._parentElementOrShadowHost(hitElement);
+    }
+    if (hitElement === targetElement) return 'done';
+    var description = this._previewNode(hitParents[0] || document.documentElement);
+    return { hitTargetDescription: description };
+  },
+
+  // Hit-target interceptor state. _hitTargetState[token] receives the verify
+  // result captured from the trusted event listener. One entry per in-flight
+  // tapOn (we only ever have one at a time in maestro flows, but keying by
+  // token keeps the state hygienic).
+  _hitTargetState: {},
+  _hitTargetNextToken: 1,
+
+  // _hitPointInTargetFrame: convert a top-frame viewport point to the
+  // target's owner-document viewport (the inverse of topFrameClickPoint).
+  // expectHitTarget always runs in the target's frame and expects coords in
+  // that frame's viewport — for iframe targets this means subtracting each
+  // ancestor iframe's box + content-area inset.
+  _hitPointInTargetFrame: function(topPoint, targetElement) {
+    var pt = { x: topPoint.x, y: topPoint.y };
+    var doc = targetElement.ownerDocument;
+    var frames = [];
+    while (doc && doc.defaultView) {
+      var iframe;
+      try { iframe = doc.defaultView.frameElement; } catch (e) { break; }
+      if (!iframe) break;
+      frames.push(iframe);
+      doc = iframe.ownerDocument;
+    }
+    // frames[0] = innermost, frames[last] = outermost. Walk outermost inward,
+    // subtracting each iframe's box.left/top + content-area inset.
+    for (var i = frames.length - 1; i >= 0; i--) {
+      var iframe = frames[i];
+      var style = this._describeIFrameStyle(iframe);
+      if (typeof style === 'string') break; // transformed/notconnected — bail
+      var box = iframe.getBoundingClientRect();
+      pt.x -= box.left + style.left;
+      pt.y -= box.top + style.top;
+    }
+    return pt;
+  },
+
+  // setupHitTargetInterceptor: install a one-shot listener that captures the
+  // ACTUAL clientX/Y of the first trusted pointerdown/mousedown event after
+  // setup, runs expectHitTarget against that point, and stashes the result
+  // for later polling by Go.
+  //
+  // Pre-flight: expectHitTarget is also run synchronously here against the
+  // computed hitPoint; if pre-flight fails (occluded, wrong element on top),
+  // we return { error } immediately so the caller skips dispatch.
+  //
+  // Why listen to the trusted event instead of just verifying after Click():
+  // by the time Click() returns, the DOM may have already mutated (e.g. the
+  // dialog handler removes the dialog). Capturing at event-fire time gives
+  // a snapshot of what was actually under the pointer when the click landed.
+  // Same pattern as Playwright's `setupHitTargetInterceptor`.
+  //
+  // Frame scope: the listener is installed on the target's owner-document
+  // window. Pointer events don't cross frame boundaries, so a top-window
+  // listener wouldn't see clicks landing inside an iframe.
+  setupHitTargetInterceptor: function(targetElement, hitPoint) {
+    // hitPoint comes in TOP-FRAME viewport coords (as computed by
+    // topFrameClickPoint). expectHitTarget runs in the target's frame, so
+    // convert before passing.
+    var localPoint = this._hitPointInTargetFrame(hitPoint, targetElement);
+    var pre = this.expectHitTarget(localPoint, targetElement);
+    if (pre !== 'done') return { error: pre.hitTargetDescription };
+
+    var self = this;
+    var token = this._hitTargetNextToken++;
+    var win = targetElement.ownerDocument && targetElement.ownerDocument.defaultView;
+    if (!win) return { error: '<target window unavailable>' };
+    var state = { captured: false, result: undefined, target: targetElement, win: win };
+    this._hitTargetState[token] = state;
+
+    var listener = function(ev) {
+      if (state.captured) return;
+      if (!ev.isTrusted) return;
+      if (ev.type !== 'pointerdown' && ev.type !== 'mousedown') return;
+      // Only interested in primary (left) button.
+      if (typeof ev.button === 'number' && ev.button !== 0) return;
+      state.captured = true;
+      try {
+        // ev.clientX/Y are in the firing window's viewport == target's frame.
+        state.result = self.expectHitTarget({ x: ev.clientX, y: ev.clientY }, state.target);
+      } catch (e) {
+        state.result = { hitTargetDescription: '<error: ' + (e && e.message) + '>' };
+      }
+      // Listener is one-shot — remove ourselves to avoid leaking handlers.
+      try {
+        state.win.removeEventListener('pointerdown', listener, true);
+        state.win.removeEventListener('mousedown', listener, true);
+      } catch (e) {}
+    };
+    state.listener = listener;
+    win.addEventListener('pointerdown', listener, true);
+    win.addEventListener('mousedown', listener, true);
+    return { token: token };
+  },
+
+  // pollHitTargetResult: returns the captured verify outcome for a token, or
+  // 'pending' if the listener hasn't fired yet. Caller should poll a few
+  // times after dispatch (a real trusted pointerdown is delivered
+  // synchronously to JS during Mouse.Click, so 'pending' should be rare —
+  // but a brief retry window absorbs scheduler jitter).
+  //
+  // After returning a non-'pending' result, the token is cleaned up.
+  pollHitTargetResult: function(token) {
+    var state = this._hitTargetState[token];
+    if (!state) return 'done'; // unknown token → don't block caller
+    if (!state.captured) return 'pending';
+    var r = state.result;
+    // Cleanup listener if still attached (defensive — listener removes itself
+    // on capture, but if the click never fired we want to stop leaking).
+    try {
+      state.win.removeEventListener('pointerdown', state.listener, true);
+      state.win.removeEventListener('mousedown', state.listener, true);
+    } catch (e) {}
+    delete this._hitTargetState[token];
+    return r;
+  },
+
+  // disposeHitTargetInterceptor: called by Go to abandon a token without
+  // waiting for a result (e.g. Mouse.Click failed before any event fired).
+  // Removes the listener and frees the slot.
+  disposeHitTargetInterceptor: function(token) {
+    var state = this._hitTargetState[token];
+    if (!state) return;
+    try {
+      state.win.removeEventListener('pointerdown', state.listener, true);
+      state.win.removeEventListener('mousedown', state.listener, true);
+    } catch (e) {}
+    delete this._hitTargetState[token];
   }
 };


### PR DESCRIPTION
## Bug

Follow-up to #71/#72 acting layer. After #71 (shadow DOM pierce) and #72 (text+index across roots), the FINDING layer for cross-root targets works. The ACTING layer was still broken: when `tapOn`'s target lives inside an iframe (or iframe + open shadow root), Rod's `Element.Click()` reads `getBoundingClientRect()` which returns iframe-LOCAL coordinates, while CDP `Input.dispatchMouseEvent` operates in TOP-FRAME viewport coordinates. The click landed somewhere meaningless and `tapOn` reported success silently.

The reporter's repro (issue #72): synthetic Flutter-shape page (iframe srcdoc → `<flt-glass-pane>` open shadow root → `<flt-semantics aria-label=\"Close\">`).

| Step | Pre-fix | Post-fix |
|---|---|---|
| `assertVisible: PARENT_HEADER_TEXT` (top frame) | ✓ | ✓ |
| `extendedWaitUntil visible: DIALOG_BODY_TEXT` (#71) | ✓ | ✓ |
| `tapOn: \"Close\"` finding | ✓ | ✓ |
| `tapOn: \"Close\"` actually closing dialog | ✗ silent false-positive | ✓ |
| `extendedWaitUntil notVisible: DIALOG_BODY_TEXT` | ✗ 5s timeout | ✓ 1ms |

## Fix

Ports microsoft/playwright `_checkFrameIsHitTarget` (`server/dom.ts`) and `setupHitTargetInterceptor` / `expectHitTarget` / `describeIFrameStyle` (`injected/injectedScript.ts`) per the maintainer's stated direction in #72.

Routes any `tapOn` whose target's `ownerDocument.defaultView.frameElement` is non-null through a new `tapOnCrossRoot` path (`commands.go`):

1. JS `topFrameClickPoint(el)` walks up the frame chain, adding each iframe's `box.left/top + content-area inset` (border + padding) at every level → top-frame viewport coord.
2. JS `setupHitTargetInterceptor(target, hitPoint)` runs `expectHitTarget` synchronously as pre-flight (per-root `elementsFromPoint` to pierce shadow boundaries) and installs a one-shot listener on the TARGET's window for trusted pointerdown/mousedown. Pointer events don't cross frame boundaries, so a top-window listener wouldn't see clicks landing inside an iframe.
3. Go-side dispatches via `page.Mouse.Click(...)` at the translated point — NOT `elem.Click()`, which is the buggy path.
4. Polls `pollHitTargetResult(token)` for the listener-captured verify outcome.

Top-frame elements (including those inside top-frame shadow roots) keep the existing `elem.Click()` path — `getBoundingClientRect()` is already in top-frame viewport coords for them.

## Implementation notes

1. **Strict transform bail.** `_describeIFrameStyle` returns `'transformed'` if iframe or any ancestor has CSS `transform != 'none'`; `topFrameClickPoint` throws. Playwright bails on transforms rather than computing through DOMMatrix; we follow that.

2. **Necessary precondition: `findBySearch` rejects IFRAME results.** CDP `DOM.performSearch` matches against the iframe element's serialized `srcdoc` attribute — for an iframe whose srcdoc HTML happens to contain the search text (which it always does for a reflective text query like `tapOn: \"Close\"`), `page.Search(\"Close\")` returns the iframe element itself. With Stage 2 hijacked, the JS Stage 3 (which walks shadow + iframe correctly via `_collectRoots()`) never gets a turn. Skipping IFRAME results in `findBySearch` lets the cascade fall through to the right element.

## Verification

Reporter's R2-hosted repro on Chromium:

```
✓ launchApp                                            (529ms)
✓ assertVisible: text=\"PARENT_HEADER_TEXT\"             (4ms)
✓ extendedWaitUntil: visible text=\"DIALOG_BODY_TEXT\"   (1ms)
✓ tapOn: text=\"Close\"                                  (393ms)
✓ extendedWaitUntil: notVisible text=\"DIALOG_BODY_TEXT\" (0ms)
✓ shadow-dom-iframe-repro 935ms
```

New table-driven test `pkg/driver/browser/cdp/commands_iframe_test.go` — 5 cases:

- A: top-frame button (regression: existing path unchanged)
- B: iframe-nested button (no shadow)
- C: iframe + open shadow root (mirrors Flutter-Web shape from #71/#72)
- D: iframe-nested button occluded by overlay (pre-flight rejects)
- E: CSS-transformed iframe (`describeIFrameStyle` bails)

Existing browser CDP suite: 319s baseline → 328s with the five new cases.

## Diff

| File | LOC |
|---|---|
| `pkg/driver/browser/cdp/commands.go` | +125 |
| `pkg/driver/browser/cdp/finder.go` | +13 |
| `pkg/driver/browser/cdp/jshelper.js` | +295 |
| `pkg/driver/browser/cdp/commands_iframe_test.go` (new) | +286 |
| **Total** | **+719** |

## Out of scope

Same iframe-coord root cause exists in `doubleTapOn` / `tapOnPoint` / `longPressOn` / `swipe` / `scrollUntilVisible`-into-iframe-content. Each currently uses Rod's iframe-local-coord path. Separate follow-up.

Single-frame hit-target verify (target's own coords) instead of the full multi-level Playwright walk. Sufficient for the common occlusion shape (overlay over the button); deeper nesting with mid-tree overlays would need the full walk. Trusted-event delivery covers parent-frame occlusion implicitly — if the iframe is occluded at parent level, pointerdown never reaches the iframe's window and the listener doesn't capture, surfacing as a verify timeout.

Refs #71 #72