### PR TITLE
fix(devicelab): validate taps against physical display, not usable height (#100)

### DIFF
--- a/pkg/driver/devicelab/commands.go
+++ b/pkg/driver/devicelab/commands.go
@@ -751,7 +751,12 @@ func (d *Driver) scrollUntilVisible(step *flow.ScrollUntilVisibleStep) *core.Com
 	}
 	deadline := time.Now().Add(timeout)
 
-	width, height, err := d.screenSize()
+	// Use the FULL physical display (same coordinate space as the hierarchy bounds). An element
+	// in the bottom system-bar band — e.g. the last nav-drawer item, centre y in
+	// (usableHeight, physicalHeight] — is genuinely on screen and tappable (see boundsTappable),
+	// so isElementOnScreen must NOT treat it as off-screen; otherwise scrollUntilVisible loops to
+	// the scroll cap on a last item that is already shown. Falls back to screenSize().
+	width, height, err := d.tappableScreenSize()
 	if err != nil {
 		return errorResult(err, "Failed to get screen size")
 	}

--- a/pkg/driver/devicelab/commands.go
+++ b/pkg/driver/devicelab/commands.go
@@ -112,7 +112,12 @@ func (d *Driver) tapOn(step *flow.TapOnStep) *core.CommandResult {
 						// desynced. A settled frame a moment later taps the real
 						// target. (Mirrors the assert-side viewport check from #39.)
 						if rectOK {
-							if sw, sh, serr := d.screenSize(); serr == nil && !boundsTappable(info.Bounds, sw, sh) {
+							// Validate against the FULL physical display (same coordinate
+							// space as info.Bounds, which come from the accessibility
+							// hierarchy). screenSize() can report the USABLE height (minus
+							// the status bar), which wrongly condemns on-screen bottom
+							// buttons/FABs whose centre sits in the bottom band.
+							if sw, sh, serr := d.tappableScreenSize(); serr == nil && !boundsTappable(info.Bounds, sw, sh) {
 								logger.Info("[devicelab] tap rejected (off-screen/malformed rect) for %s: w=%d h=%d center=(%d,%d) screen=%dx%d — re-polling",
 									step.Selector.Describe(), info.Bounds.Width, info.Bounds.Height,
 									info.Bounds.X+info.Bounds.Width/2, info.Bounds.Y+info.Bounds.Height/2, sw, sh)

--- a/pkg/driver/devicelab/driver.go
+++ b/pkg/driver/devicelab/driver.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -106,15 +107,17 @@ type Driver struct {
 	// Cached values to avoid repeated ADB shell calls
 	cachedAPILevel   int
 	cachedActivities map[string]string // appID -> activity
+	cachedScreenW    int               // physical display width  (from `wm size`)
+	cachedScreenH    int               // physical display height (from `wm size`)
 
 	// CDP state from background push events (nil = not wired)
 	cdpStateFunc func() *core.CDPInfo
 
 	// WebView CDP connection manager (nil = not wired)
-	webView        *webViewManager
-	lastCDPScan    time.Time     // rate-limit ADB shell CDP scans
-	lastCDPResult  *core.CDPInfo // cached result from last scan
-	knownCDPType   string        // "browser" or "webview" — set from socket name, cleared on CDP down
+	webView       *webViewManager
+	lastCDPScan   time.Time     // rate-limit ADB shell CDP scans
+	lastCDPResult *core.CDPInfo // cached result from last scan
+	knownCDPType  string        // "browser" or "webview" — set from socket name, cleared on CDP down
 
 	// Lazy retry state: each successful tap captures the pre-tap tree hash
 	// + selector + time. If the NEXT element-based command can't find its
@@ -131,9 +134,9 @@ type Driver struct {
 // "recent enough" to retry. Probe: how long we let the next command poll
 // before doing the hash check. Max: retry cap per original tap.
 const (
-	lazyRetryWindow   = 2 * time.Second
-	lazyRetryProbeMs  = 500
-	lazyRetryMax      = 2
+	lazyRetryWindow  = 2 * time.Second
+	lazyRetryProbeMs = 500
+	lazyRetryMax     = 2
 )
 
 // lazyRetryEnabled gates the host-side lazy tap-retry. OFF by default.
@@ -244,6 +247,7 @@ func (d *Driver) recordTap(sel flow.Selector) {
 //   - a tap happened recently (within lazyRetryWindow)
 //   - the tree hash hasn't changed since that tap (screen unchanged)
 //   - we haven't exceeded lazyRetryMax for this tap
+//
 // If all true, it re-issues the prior tap and returns true so the caller
 // knows to keep polling. Returns false otherwise (caller continues its
 // normal failure path).
@@ -350,6 +354,77 @@ func (d *Driver) screenSize() (int, int, error) {
 		return d.info.ScreenWidth, d.info.ScreenHeight, nil
 	}
 	return 0, 0, fmt.Errorf("screen dimensions not available")
+}
+
+// physicalScreenSize returns the full physical display size (e.g. 1080x2340 from
+// `wm size`), cached for the session. Unlike screenSize() — which returns the
+// on-device-reported USABLE size (it can exclude the status bar, e.g. 1080x2204) —
+// this matches the coordinate space of the accessibility hierarchy (whose root spans
+// the full display), so it is the correct reference for on-screen geometry checks
+// against element bounds. Returns ok=false if it cannot be determined.
+func (d *Driver) physicalScreenSize() (int, int, bool) {
+	if d.cachedScreenW > 0 && d.cachedScreenH > 0 {
+		return d.cachedScreenW, d.cachedScreenH, true
+	}
+	if d.device == nil {
+		return 0, 0, false
+	}
+	out, err := d.device.Shell("wm size")
+	if err != nil {
+		return 0, 0, false
+	}
+	w, h := parseWmSize(out)
+	if w <= 0 || h <= 0 {
+		return 0, 0, false
+	}
+	d.cachedScreenW, d.cachedScreenH = w, h
+	return w, h, true
+}
+
+// tappableScreenSize returns the screen size used to validate element bounds: the
+// full physical display (same coordinate space as the accessibility hierarchy that
+// produced the bounds), falling back to the on-device-reported size when the
+// physical size is unavailable.
+func (d *Driver) tappableScreenSize() (int, int, error) {
+	if w, h, ok := d.physicalScreenSize(); ok {
+		return w, h, nil
+	}
+	return d.screenSize()
+}
+
+// parseWmSize extracts width x height from `wm size` output. It prefers an
+// "Override size" line (the effective display size when one is set) over the
+// "Physical size" line.
+func parseWmSize(out string) (int, int) {
+	var pw, ph, ow, oh int
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(line, "Physical size:"):
+			pw, ph = parseWxH(strings.TrimPrefix(line, "Physical size:"))
+		case strings.HasPrefix(line, "Override size:"):
+			ow, oh = parseWxH(strings.TrimPrefix(line, "Override size:"))
+		}
+	}
+	if ow > 0 && oh > 0 {
+		return ow, oh
+	}
+	return pw, ph
+}
+
+// parseWxH parses "1080x2340" (tolerating surrounding spaces) into width, height.
+func parseWxH(s string) (int, int) {
+	s = strings.TrimSpace(s)
+	i := strings.IndexByte(s, 'x')
+	if i <= 0 {
+		return 0, 0
+	}
+	w, err1 := strconv.Atoi(strings.TrimSpace(s[:i]))
+	h, err2 := strconv.Atoi(strings.TrimSpace(s[i+1:]))
+	if err1 != nil || err2 != nil {
+		return 0, 0
+	}
+	return w, h
 }
 
 // SetContext sets the parent context for element-finding operations.
@@ -671,19 +746,19 @@ func (d *Driver) scanCDPSocket() *core.CDPInfo {
 // knownBrowserPackages is the set of Android packages that are browsers.
 // Matches the on-device Java agent's browser detection logic.
 var knownBrowserPackages = map[string]bool{
-	"com.android.chrome":        true,
-	"com.chrome.beta":           true,
-	"com.chrome.dev":            true,
-	"com.chrome.canary":         true,
-	"org.chromium.chrome":       true,
-	"app.vanadium.browser":      true,
-	"org.mozilla.firefox":       true,
-	"org.mozilla.firefox_beta":  true,
-	"com.opera.browser":         true,
-	"com.opera.mini.native":     true,
-	"com.brave.browser":         true,
-	"com.microsoft.emmx":        true,
-	"com.vivaldi.browser":       true,
+	"com.android.chrome":           true,
+	"com.chrome.beta":              true,
+	"com.chrome.dev":               true,
+	"com.chrome.canary":            true,
+	"org.chromium.chrome":          true,
+	"app.vanadium.browser":         true,
+	"org.mozilla.firefox":          true,
+	"org.mozilla.firefox_beta":     true,
+	"com.opera.browser":            true,
+	"com.opera.mini.native":        true,
+	"com.brave.browser":            true,
+	"com.microsoft.emmx":           true,
+	"com.vivaldi.browser":          true,
 	"com.sec.android.app.sbrowser": true,
 }
 

--- a/pkg/driver/devicelab/physicalscreen_test.go
+++ b/pkg/driver/devicelab/physicalscreen_test.go
@@ -68,6 +68,22 @@ func TestTappableScreenSize_FallsBackToReported(t *testing.T) {
 	}
 }
 
+// TestIsElementOnScreen_BottomBand is the scroll-side analogue of the tap fix: the last
+// nav-drawer item ("Configuration") sits in the bottom system-bar band — bounds [61,2208][709,2340]
+// on a 1080x2340 display whose USABLE height is 2204. It is genuinely on screen and tappable, so
+// isElementOnScreen must accept it when given the PHYSICAL height; otherwise scrollUntilVisible
+// loops to the scroll cap on an item that is already shown. scrollUntilVisible now sources the
+// height from tappableScreenSize() (physical) for exactly this reason.
+func TestIsElementOnScreen_BottomBand(t *testing.T) {
+	lastDrawerItem := &core.ElementInfo{Bounds: core.Bounds{X: 61, Y: 2208, Width: 648, Height: 132}}
+	if isElementOnScreen(lastDrawerItem, 1080, 2204) {
+		t.Errorf("sanity: y=2208 must be off-screen against usable height 2204 (the bug)")
+	}
+	if !isElementOnScreen(lastDrawerItem, 1080, 2340) {
+		t.Errorf("last drawer item (y=2208..2340) must be on-screen against physical height 2340")
+	}
+}
+
 func TestPhysicalScreenSize_CachesWmSize(t *testing.T) {
 	shell := &mockShell{out: "Physical size: 1080x2340\n"}
 	d := New(&mockDeviceLabClient{}, &core.PlatformInfo{}, shell)

--- a/pkg/driver/devicelab/physicalscreen_test.go
+++ b/pkg/driver/devicelab/physicalscreen_test.go
@@ -1,0 +1,82 @@
+package devicelab
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/devicelab-dev/maestro-runner/pkg/core"
+)
+
+func TestParseWmSize(t *testing.T) {
+	cases := []struct {
+		name         string
+		out          string
+		wantW, wantH int
+	}{
+		{"physical only", "Physical size: 1080x2340\n", 1080, 2340},
+		{"override preferred over physical", "Physical size: 1080x2340\nOverride size: 1080x2160\n", 1080, 2160},
+		{"crlf and surrounding spaces", "  Physical size: 720x1280  \r\n", 720, 1280},
+		{"garbage", "error: could not access display", 0, 0},
+		{"empty", "", 0, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			w, h := parseWmSize(c.out)
+			if w != c.wantW || h != c.wantH {
+				t.Errorf("parseWmSize(%q) = %dx%d, want %dx%d", c.out, w, h, c.wantW, c.wantH)
+			}
+		})
+	}
+}
+
+// TestTappableScreenSize_UsesPhysicalNotUsable is the regression for the off-screen
+// tap bug: the on-device driver reports the USABLE height (2204 = 2340 - 136px status
+// bar), but element bounds come from the accessibility hierarchy in full-display
+// coords. A bottom-anchored AlertDialog button at centre y=2219 is on screen
+// (2219 < 2340) yet would be rejected against the usable height (2219 >= 2204). The
+// tap guard must use the physical display size.
+func TestTappableScreenSize_UsesPhysicalNotUsable(t *testing.T) {
+	shell := &mockShell{out: "Physical size: 1080x2340\n"}
+	d := New(&mockDeviceLabClient{}, &core.PlatformInfo{ScreenWidth: 1080, ScreenHeight: 2204}, shell)
+
+	sw, sh, err := d.tappableScreenSize()
+	if err != nil {
+		t.Fatalf("tappableScreenSize: %v", err)
+	}
+	if sw != 1080 || sh != 2340 {
+		t.Fatalf("tappableScreenSize = %dx%d, want 1080x2340 (physical, not usable 2204)", sw, sh)
+	}
+
+	// Bottom dialog button: bounds [764,2153][976,2285], centre (870,2219).
+	bottomBtn := core.Bounds{X: 764, Y: 2153, Width: 212, Height: 132}
+	if !boundsTappable(bottomBtn, sw, sh) {
+		t.Errorf("bottom button (centre y=2219) should be tappable on a 2340-tall display")
+	}
+	// Sanity: against the (wrong) usable height it is rejected — that was the bug.
+	if boundsTappable(bottomBtn, 1080, 2204) {
+		t.Errorf("centre y=2219 must be rejected against usable height 2204 (bug repro)")
+	}
+}
+
+func TestTappableScreenSize_FallsBackToReported(t *testing.T) {
+	// Physical size unavailable (shell errors) → fall back to PlatformInfo.
+	shell := &mockShell{err: errors.New("no shell")}
+	d := New(&mockDeviceLabClient{}, &core.PlatformInfo{ScreenWidth: 1080, ScreenHeight: 2204}, shell)
+	sw, sh, err := d.tappableScreenSize()
+	if err != nil || sw != 1080 || sh != 2204 {
+		t.Fatalf("fallback tappableScreenSize = %dx%d err=%v, want 1080x2204", sw, sh, err)
+	}
+}
+
+func TestPhysicalScreenSize_CachesWmSize(t *testing.T) {
+	shell := &mockShell{out: "Physical size: 1080x2340\n"}
+	d := New(&mockDeviceLabClient{}, &core.PlatformInfo{}, shell)
+	for i := 0; i < 3; i++ {
+		if w, h, ok := d.physicalScreenSize(); !ok || w != 1080 || h != 2340 {
+			t.Fatalf("physicalScreenSize() = %dx%d ok=%v, want 1080x2340 true", w, h, ok)
+		}
+	}
+	if len(shell.commands) != 1 || shell.commands[0] != "wm size" {
+		t.Errorf("expected exactly one `wm size` shell call (cached), got %v", shell.commands)
+	}
+}


### PR DESCRIPTION
Fixes #100.

## Problem

`tapOn`'s on-screen guard (`boundsTappable`) compares element bounds — which come from the accessibility hierarchy in **full-display** coordinates — against `PlatformInfo.ScreenHeight`. The on-device driver can report that as the **usable** height (excludes the status bar), e.g. `1080x2204` on a `1080x2340` device. So on-screen bottom-anchored `AlertDialog` buttons / FABs whose centre falls in the bottom band (centre `y ≈ 2219`) are rejected:

```
[devicelab] tap rejected (off-screen/malformed rect) for #android:id/button1: ... center=(870,2219) screen=1080x2204 — re-polling
[ERROR] tapOn ... context deadline exceeded
```

UIAutomator2 taps those same elements fine (no such guard). Full diagnosis in #100.

## Fix

- `physicalScreenSize()` — reads the full physical display via `wm size` (cached per session).
- `tappableScreenSize()` — prefers the physical size, falls back to the reported `screenSize()` when `wm size` is unavailable.
- The `tapOn` guard now uses `tappableScreenSize()`, so bounds are validated in the **same coordinate space** they were produced in. The `#94` malformed-rect rejection (non-positive width/height, far-off-screen centre) is unchanged.

This is option 2 from the issue (self-contained Go fix, no on-device change). If you'd prefer the on-device driver to report the physical size in `PlatformInfo` instead (option 1), happy to adjust.

## Tests (`pkg/driver/devicelab/physicalscreen_test.go`)

- `TestParseWmSize` — Physical, Override-preferred-over-Physical, CRLF/spaces, garbage, empty.
- `TestTappableScreenSize_UsesPhysicalNotUsable` — the regression: reported `2204` but `wm size` `2340` → guard uses `2340` → the bottom button (centre `y=2219`) is tappable; rejected against `2204` (the bug).
- `TestTappableScreenSize_FallsBackToReported`, `TestPhysicalScreenSize_CachesWmSize` (asserts a single `wm size` call).

`go build ./...`, `go vet ./pkg/driver/devicelab/`, and `go test ./pkg/driver/devicelab/` all pass.
