### PR TITLE
fix(drivers): scrollUntilVisible accepts malformed (negative-area) rects that tapOn rejects

### DIFF
--- a/pkg/driver/devicelab/commands.go
+++ b/pkg/driver/devicelab/commands.go
@@ -845,10 +845,15 @@ func (d *Driver) scrollByAdb(direction string, screenWidth, screenHeight int, pe
 const scrollDurationMs = 300
 
 // isElementOnScreen reports whether an element's bounds overlap the visible
-// viewport. Zero-area bounds count as off-screen.
+// viewport. Malformed bounds — non-positive width/height, e.g. a clipped
+// below-the-fold ScrollView child reported with top>bottom (negative height) —
+// count as off-screen, matching boundsTappable's #94 guard. Without this,
+// scrollUntilVisible short-circuits to success on a degenerate rect that tapOn
+// then refuses to tap ("element rect not tappable"), looping to the deadline
+// instead of scrolling the element fully into view.
 func isElementOnScreen(info *core.ElementInfo, screenWidth, screenHeight int) bool {
 	b := info.Bounds
-	if b.Width == 0 || b.Height == 0 {
+	if b.Width <= 0 || b.Height <= 0 {
 		return false
 	}
 	return b.X+b.Width > 0 && b.X < screenWidth && b.Y+b.Height > 0 && b.Y < screenHeight

--- a/pkg/driver/devicelab/commands_test.go
+++ b/pkg/driver/devicelab/commands_test.go
@@ -180,6 +180,13 @@ func TestIsElementOnScreen(t *testing.T) {
 		{"entirely right of screen", core.Bounds{X: 1080, Y: 100, Width: 200, Height: 200}, false},
 		{"zero width", core.Bounds{X: 100, Y: 100, Width: 0, Height: 200}, false},
 		{"zero height", core.Bounds{X: 100, Y: 100, Width: 200, Height: 0}, false},
+		{"negative width", core.Bounds{X: 100, Y: 100, Width: -50, Height: 200}, false},
+		// Repro from the field: a clipped below-the-fold ScrollView button the
+		// agent reports with top>bottom (raw [270,2300][1080,2274] → h=-26,
+		// centre (675,2287)). Overlaps the viewport numerically, but is a
+		// degenerate rect tapOn refuses (boundsTappable's #94 guard); the scroll
+		// success predicate must reject it too so the loop keeps scrolling.
+		{"negative height (clipped below-fold)", core.Bounds{X: 270, Y: 2300, Width: 810, Height: -26}, false},
 	}
 
 	for _, tt := range tests {

--- a/pkg/driver/uiautomator2/commands.go
+++ b/pkg/driver/uiautomator2/commands.go
@@ -523,10 +523,12 @@ func (d *Driver) scrollByAdb(direction string, screenWidth, screenHeight int, pe
 }
 
 // isElementOnScreen reports whether an element's bounds overlap the visible
-// viewport. Zero-area bounds count as off-screen.
+// viewport. Malformed bounds (non-positive width/height — e.g. a clipped rect
+// with top>bottom) count as off-screen, so scrollUntilVisible keeps scrolling
+// instead of declaring success on a degenerate rect.
 func isElementOnScreen(info *core.ElementInfo, screenWidth, screenHeight int) bool {
 	b := info.Bounds
-	if b.Width == 0 || b.Height == 0 {
+	if b.Width <= 0 || b.Height <= 0 {
 		return false
 	}
 	return b.X+b.Width > 0 && b.X < screenWidth && b.Y+b.Height > 0 && b.Y < screenHeight

--- a/pkg/driver/uiautomator2/commands_test.go
+++ b/pkg/driver/uiautomator2/commands_test.go
@@ -4180,6 +4180,10 @@ func TestIsElementOnScreen(t *testing.T) {
 		{"entirely above screen", core.Bounds{X: 100, Y: -300, Width: 200, Height: 200}, false},
 		{"zero width", core.Bounds{X: 100, Y: 100, Width: 0, Height: 200}, false},
 		{"zero height", core.Bounds{X: 100, Y: 100, Width: 200, Height: 0}, false},
+		{"negative width", core.Bounds{X: 100, Y: 100, Width: -50, Height: 200}, false},
+		// Malformed clipped rect (top>bottom → negative height): degenerate, must
+		// count as off-screen so scrollUntilVisible keeps scrolling.
+		{"negative height (clipped)", core.Bounds{X: 270, Y: 2300, Width: 810, Height: -26}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Follow-up to the discussion in #101.

## Problem

`scrollUntilVisible` declares success and stops scrolling, then a `tapOn` on the **same element** fails with a deterministic signature:

```
✓ scrollUntilVisible id=…/extintoresInstalacionParte (729ms)
✗ tapOn              id=…/extintoresInstalacionParte (12.0s)
   element rect not tappable (w=810 h=-26 center=(675,2287) screen=1080x2340)
```

Note `h=-26`: the element's bounds are a **malformed rect with top > bottom** (negative height). Reproduces on the `devicelab` driver against a button at the bottom of a `ScrollView` that is still below the fold when the scroll loop stops. `uiautomator2` taps the same button fine.

## Root cause

The scroll-stop predicate and the tap predicate disagree on what counts as a valid on-screen rect:

- `boundsTappable` (used by `tapOn`) rejects non-positive dimensions — the #94 malformed-rect guard:
  ```go
  if b.Width <= 0 || b.Height <= 0 { return false }
  ```
- `isElementOnScreen` (used by `scrollUntilVisible`) only rejected **exactly zero**:
  ```go
  if b.Width == 0 || b.Height == 0 { return false }
  ```

A clipped below-the-fold `ScrollView` child is reported with top > bottom (raw `[270,2300][1080,2274]` → `h=-26`, centre `(675,2287)`). `isElementOnScreen` accepts it — it isn't *exactly* zero, and it numerically "overlaps" the viewport — so `scrollUntilVisible` short-circuits to success without ever scrolling the button into view. `tapOn` then correctly refuses the same degenerate rect via the #94 guard and re-polls to the deadline.

This is **independent of the usable-vs-physical height fix in #101**: the inverted rect comes from *clipping*, not from the screen-size value, so it reproduces even when `isElementOnScreen` is given the physical height (as it now is post-#101 via `tappableScreenSize()`).

## Fix

Make `isElementOnScreen` reject non-positive width/height, matching `boundsTappable`'s #94 guard. The scroll loop then keeps going until the element has a real, on-screen rect, and the following `tapOn` succeeds. This stays a defensive Go-side guard in the same spirit as #101 — no magic tolerance — so the #94 malformed-rect rejection is now consistent on both the tap side and the scroll side.

Applied to **both** the `devicelab` and `uiautomator2` drivers: the predicate is duplicated and identical in each. Only the `devicelab` path was observed failing in the field; the `uiautomator2` edit has no independent repro but keeps the two predicates consistent and is unambiguously correct (a negative-area rect is never visible).

## Tests

- New regression cases in both `TestIsElementOnScreen` tables (`pkg/driver/devicelab`, `pkg/driver/uiautomator2`): `negative width` and `negative height (clipped …)`, the latter the exact field repro `{X:270, Y:2300, Width:810, Height:-26}`. Each must return `false`; against the old `== 0` predicate they return `true`, so they fail without the fix.
- `go build ./...`, `go vet ./pkg/driver/devicelab/ ./pkg/driver/uiautomator2/`, and `go test ./pkg/driver/devicelab/ ./pkg/driver/uiautomator2/` all pass.
- End-to-end on a local API 33 arm64 emulator: a flow that scrolls to a bottom-anchored `ScrollView` button and taps it now passes 21/21 (`tapOn` 1.3s vs the prior 12s deadline).
