### PR TITLE
chore: make repository REUSE-compliant and improve copyright attribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,9 @@ jobs:
         with:
           version: latest
 
+      - name: REUSE Compliance Check
+        uses: fsfe/reuse-action@v6
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,10 @@ Add support for swipe gestures
 - Add godoc comments for exported APIs
 - Update CHANGELOG.md for notable changes
 
+### License Headers
+
+This project adheres to the REUSE specification. When creating new files, please include the appropriate copyright and SPDX license headers, or define their licensing in `REUSE.toml`. Our CI pipeline will check for REUSE compliance automatically.
+
 ## Project Structure
 
 See [DEVELOPER.md](DEVELOPER.md) for architecture details and extension guides.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,15 @@
+# Contributors
+
+Thanks to the DeviceLab team and everyone who has contributed to this project!
+
+If you have contributed but are missing here, please let us know.
+
+Om Narayan
+Naga Venkatesh Sankar R
+Gabriel Almeida
+Mario Rial
+Mahesh Tiyyagura
+Junyoung Yoon
+Eyal Yovel
+Alejandro Maggi
+Phen Chua

--- a/LICENSE
+++ b/LICENSE
@@ -176,7 +176,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2024–2026 DeviceLab
+   Copyright 2024–2026 DeviceLab and the Project Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -176,7 +176,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2024 DeviceLab
+   Copyright 2024–2026 DeviceLab
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSES/LicenseRef-CocoaHTTPServer.txt
+++ b/LICENSES/LicenseRef-CocoaHTTPServer.txt
@@ -1,0 +1,18 @@
+Software License Agreement (BSD License)
+
+Copyright (c) 2011, Deusty, LLC
+All rights reserved.
+
+Redistribution and use of this software in source and binary forms,
+with or without modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above
+  copyright notice, this list of conditions and the
+  following disclaimer.
+
+* Neither the name of Deusty nor the names of its
+  contributors may be used to endorse or promote products
+  derived from this software without specific prior
+  written permission of Deusty, LLC.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSES/LicenseRef-RoutingHTTPServer.txt
+++ b/LICENSES/LicenseRef-RoutingHTTPServer.txt
@@ -1,0 +1,19 @@
+Copyright (c) 2011 Matt Stevens
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/LICENSES/LicenseRef-agent-device.txt
+++ b/LICENSES/LicenseRef-agent-device.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Callstack
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSES/LicenseRef-appium-WebDriverAgent.txt
+++ b/LICENSES/LicenseRef-appium-WebDriverAgent.txt
@@ -1,0 +1,30 @@
+BSD License
+
+For WebDriverAgent software
+
+Copyright (c) 2015-present, Facebook, Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+ * Neither the name Facebook nor the names of its contributors may be used to
+   endorse or promote products derived from this software without specific
+   prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSES/LicenseRef-appium-uiautomator2-server.txt
+++ b/LICENSES/LicenseRef-appium-uiautomator2-server.txt
@@ -1,0 +1,201 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction,
+and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by
+the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all
+other entities that control, are controlled by, or are under common
+control with that entity. For the purposes of this definition,
+"control" means (i) the power, direct or indirect, to cause the
+direction or management of such entity, whether by contract or
+otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity
+exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation
+source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical
+transformation or translation of a Source form, including but
+not limited to compiled object code, generated documentation,
+and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or
+Object form, made available under the License, as indicated by a
+copyright notice that is included in or attached to the work
+(an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object
+form, that is based on (or derived from) the Work and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship. For the purposes
+of this License, Derivative Works shall not include works that remain
+separable from, or merely link (or bind by name) to the interfaces of,
+the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including
+the original version of the Work and any modifications or additions
+to that Work or Derivative Works thereof, that is intentionally
+submitted to Licensor for inclusion in the Work by the copyright owner
+or by an individual or Legal Entity authorized to submit on behalf of
+the copyright owner. For the purposes of this definition, "submitted"
+means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems,
+and issue tracking systems that are managed by, or on behalf of, the
+Licensor for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise
+designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity
+on behalf of whom a Contribution has been received by Licensor and
+subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the
+Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made,
+use, offer to sell, sell, import, and otherwise transfer the Work,
+where such license applies only to those patent claims licensable
+by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s)
+with the Work to which such Contribution(s) was submitted. If You
+institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work
+or a Contribution incorporated within the Work constitutes direct
+or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate
+as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+Work or Derivative Works thereof in any medium, with or without
+modifications, and in Source or Object form, provided that You
+meet the following conditions:
+
+(a) You must give any other recipients of the Work or
+Derivative Works a copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices
+stating that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works
+that You distribute, all copyright, patent, trademark, and
+attribution notices from the Source form of the Work,
+excluding those notices that do not pertain to any part of
+the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its
+distribution, then any Derivative Works that You distribute must
+include a readable copy of the attribution notices contained
+within such NOTICE file, excluding those notices that do not
+pertain to any part of the Derivative Works, in at least one
+of the following places: within a NOTICE text file distributed
+as part of the Derivative Works; within the Source form or
+documentation, if provided along with the Derivative Works; or,
+within a display generated by the Derivative Works, if and
+wherever such third-party notices normally appear. The contents
+of the NOTICE file are for informational purposes only and
+do not modify the License. You may add Your own attribution
+notices within Derivative Works that You distribute, alongside
+or as an addendum to the NOTICE text from the Work, provided
+that such additional attribution notices cannot be construed
+as modifying the License.
+
+You may add Your own copyright statement to Your modifications and
+may provide additional or different license terms and conditions
+for use, reproduction, or distribution of Your modifications, or
+for any such Derivative Works as a whole, provided Your use,
+reproduction, and distribution of the Work otherwise complies with
+the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+any Contribution intentionally submitted for inclusion in the Work
+by You to the Licensor shall be under the terms and conditions of
+this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify
+the terms of any separate license agreement you may have executed
+with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+names, trademarks, service marks, or product names of the Licensor,
+except as required for reasonable and customary use in describing the
+origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+agreed to in writing, Licensor provides the Work (and each
+Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied, including, without limitation, any warranties or conditions
+of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any
+risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+whether in tort (including negligence), contract, or otherwise,
+unless required by applicable law (such as deliberate and grossly
+negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special,
+incidental, or consequential damages of any character arising as a
+result of this License or out of the use or inability to use the
+Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all
+other commercial damages or losses), even if such Contributor
+has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+the Work or Derivative Works thereof, You may choose to offer,
+and charge a fee for, acceptance of support, warranty, indemnity,
+or other liability obligations and/or rights consistent with this
+License. However, in accepting such obligations, You may act only
+on Your own behalf and on Your sole responsibility, not on behalf
+of any other Contributor, and only if You agree to indemnify,
+defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason
+of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "{}"
+replaced with your own identifying information. (Don't include
+the brackets!)  The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright JS Foundation and other contributors, https://js.foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSES/LicenseRef-maestro-runner.txt
+++ b/LICENSES/LicenseRef-maestro-runner.txt
@@ -1,0 +1,191 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright
+      owner or by an individual or Legal Entity authorized to submit on
+      behalf of the copyright owner. For the purposes of this definition,
+      "submitted" means any form of electronic, verbal, or written
+      communication sent to the Licensor or its representatives, including
+      but not limited to communication on electronic mailing lists, source
+      code control systems, and issue tracking systems that are managed by,
+      or on behalf of, the Licensor for the purpose of discussing and
+      improving the Work, but excluding communication that is conspicuously
+      marked or otherwise designated in writing by the copyright owner as
+      "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2024 DeviceLab
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSES/LicenseRef-maestro-runner.txt
+++ b/LICENSES/LicenseRef-maestro-runner.txt
@@ -176,7 +176,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2024–2026 DeviceLab
+   Copyright 2024–2026 DeviceLab and the Project Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSES/LicenseRef-maestro-runner.txt
+++ b/LICENSES/LicenseRef-maestro-runner.txt
@@ -176,7 +176,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2024 DeviceLab
+   Copyright 2024–2026 DeviceLab
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -8,6 +8,7 @@ path = [
   "CHANGELOG.md",
   "CODE_OF_CONDUCT.md",
   "CONTRIBUTING.md",
+  "CONTRIBUTORS.md",
   "DESIGN.md",
   "DEVELOPER.md",
   "LICENSE",

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,66 @@
+version = 1
+
+[[annotations]]
+path = [
+  ".github/**",
+  ".gitignore",
+  ".goreleaser.yml",
+  "CHANGELOG.md",
+  "CODE_OF_CONDUCT.md",
+  "CONTRIBUTING.md",
+  "DESIGN.md",
+  "DEVELOPER.md",
+  "LICENSE",
+  "Makefile",
+  "README.md",
+  "codecov.yml",
+  "docs/**",
+  "go.mod",
+  "go.sum",
+  "llms.txt",
+  "drivers/ios/DevicelabIOSRunner/DevicelabIOSRunner.xcodeproj/**",
+  "drivers/ios/DevicelabIOSRunner/PROTOCOL.md",
+  "drivers/ios/DevicelabIOSRunner/README.md",
+  "drivers/ios/DevicelabIOSRunner/project.yml",
+  "drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/ATTRIBUTION.md",
+  # "drivers/android/devicelab-android-driver.apk",
+  # "drivers/android/devicelab-android-driver-test.apk",
+  # "drivers/android/settings_apk-debug.apk",
+]
+SPDX-FileCopyrightText = "2024 DeviceLab"
+SPDX-License-Identifier = "LicenseRef-maestro-runner"
+
+[[annotations]]
+path = [
+  "drivers/android/appium-uiautomator2-server-debug-androidTest.apk",
+  "drivers/android/appium-uiautomator2-server-v9.11.1.apk",
+]
+SPDX-FileCopyrightText = "JS Foundation and other contributors, https://js.foundation"
+SPDX-License-Identifier = "LicenseRef-appium-uiautomator2-server"
+
+[[annotations]]
+path = [
+  "drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests*.swift",
+  "drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerObjCExceptionCatcher.h",
+  "drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerObjCExceptionCatcher.m",
+]
+SPDX-FileCopyrightText = "2026 Callstack"
+SPDX-License-Identifier = "LicenseRef-agent-device"
+
+[[annotations]]
+path = [
+  "drivers/ios/WebDriverAgent/**",
+  "drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/PrivateHeaders/**",
+]
+SPDX-FileCopyrightText = "2015-present, Facebook, Inc."
+SPDX-License-Identifier = "LicenseRef-appium-WebDriverAgent"
+
+[[annotations]]
+path = "drivers/ios/WebDriverAgent/WebDriverAgentLib/Vendor/CocoaHTTPServer/**"
+SPDX-FileCopyrightText = "2011, Deusty, LLC"
+SPDX-License-Identifier = "LicenseRef-CocoaHTTPServer"
+
+[[annotations]]
+path = "drivers/ios/WebDriverAgent/WebDriverAgentLib/Vendor/RoutingHTTPServer/**"
+SPDX-FileCopyrightText = "2011 Matt Stevens"
+SPDX-License-Identifier = "LicenseRef-RoutingHTTPServer"

--- a/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunner/App.swift
+++ b/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunner/App.swift
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunner/App.swift
+++ b/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunner/App.swift
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 import SwiftUI
 
 @main

--- a/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunner/App.swift
+++ b/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunner/App.swift
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunner/App.swift
+++ b/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunner/App.swift
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/Bridging-Header.h
+++ b/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/Bridging-Header.h
@@ -1,2 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: 2024 DeviceLab
+ *
+ * SPDX-License-Identifier: LicenseRef-maestro-runner
+ */
+
 #import "RunnerObjCExceptionCatcher.h"
 #import "SyntheticTyping.h"

--- a/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/Bridging-Header.h
+++ b/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/Bridging-Header.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 DeviceLab
+ * SPDX-FileCopyrightText: 2024–2026 DeviceLab
  *
  * SPDX-License-Identifier: LicenseRef-maestro-runner
  */

--- a/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/Bridging-Header.h
+++ b/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/Bridging-Header.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024–2026 DeviceLab
+ * SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
  *
  * SPDX-License-Identifier: LicenseRef-maestro-runner
  */

--- a/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/PixelDiff.swift
+++ b/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/PixelDiff.swift
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/PixelDiff.swift
+++ b/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/PixelDiff.swift
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/PixelDiff.swift
+++ b/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/PixelDiff.swift
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 // Local file (not in upstream agent-device). Computes the fraction of
 // differing pixels between two UIImages by drawing each into a raw RGBA
 // byte buffer via CGContext and comparing those buffers directly. Used

--- a/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/PixelDiff.swift
+++ b/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/PixelDiff.swift
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+CommandExecution.swift
+++ b/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+CommandExecution.swift
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Callstack
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-agent-device
 

--- a/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+CommandExecution.swift
+++ b/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+CommandExecution.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Callstack
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-agent-device
+
 import XCTest
 
 extension RunnerTests {

--- a/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+CommandExecution.swift
+++ b/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+CommandExecution.swift
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Callstack
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-agent-device
 

--- a/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+CommandExecution.swift
+++ b/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+CommandExecution.swift
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Callstack
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-agent-device
 

--- a/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+Environment.swift
+++ b/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+Environment.swift
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Callstack
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-agent-device
 

--- a/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+Environment.swift
+++ b/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+Environment.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Callstack
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-agent-device
+
 import Foundation
 
 // MARK: - Environment

--- a/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+Environment.swift
+++ b/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+Environment.swift
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Callstack
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-agent-device
 

--- a/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+Environment.swift
+++ b/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+Environment.swift
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Callstack
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-agent-device
 

--- a/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+Interaction.swift
+++ b/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+Interaction.swift
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Callstack
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-agent-device
 

--- a/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+Interaction.swift
+++ b/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+Interaction.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Callstack
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-agent-device
+
 import XCTest
 
 extension RunnerTests {

--- a/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+Interaction.swift
+++ b/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+Interaction.swift
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Callstack
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-agent-device
 

--- a/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+Interaction.swift
+++ b/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+Interaction.swift
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Callstack
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-agent-device
 

--- a/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+Models.swift
+++ b/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+Models.swift
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Callstack
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-agent-device
 

--- a/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+Models.swift
+++ b/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+Models.swift
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Callstack
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-agent-device
 

--- a/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+Models.swift
+++ b/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+Models.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Callstack
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-agent-device
+
 // MARK: - Wire Models
 
 enum CommandType: String, Codable {

--- a/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+Models.swift
+++ b/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+Models.swift
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Callstack
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-agent-device
 

--- a/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+Snapshot.swift
+++ b/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+Snapshot.swift
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Callstack
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-agent-device
 

--- a/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+Snapshot.swift
+++ b/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+Snapshot.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Callstack
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-agent-device
+
 import XCTest
 
 extension RunnerTests {

--- a/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+Snapshot.swift
+++ b/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+Snapshot.swift
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Callstack
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-agent-device
 

--- a/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+Snapshot.swift
+++ b/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+Snapshot.swift
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Callstack
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-agent-device
 

--- a/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+SystemModal.swift
+++ b/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+SystemModal.swift
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Callstack
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-agent-device
 

--- a/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+SystemModal.swift
+++ b/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+SystemModal.swift
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Callstack
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-agent-device
+
 import XCTest
 
 extension RunnerTests {

--- a/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+SystemModal.swift
+++ b/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+SystemModal.swift
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Callstack
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-agent-device
 

--- a/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+SystemModal.swift
+++ b/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/RunnerTests+SystemModal.swift
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 Callstack
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-agent-device
 

--- a/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/SyntheticTyping.h
+++ b/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/SyntheticTyping.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2024 DeviceLab
+ *
+ * SPDX-License-Identifier: LicenseRef-maestro-runner
+ */
+
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/SyntheticTyping.h
+++ b/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/SyntheticTyping.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024 DeviceLab
+ * SPDX-FileCopyrightText: 2024–2026 DeviceLab
  *
  * SPDX-License-Identifier: LicenseRef-maestro-runner
  */

--- a/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/SyntheticTyping.h
+++ b/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/SyntheticTyping.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024–2026 DeviceLab
+ * SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
  *
  * SPDX-License-Identifier: LicenseRef-maestro-runner
  */

--- a/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/SyntheticTyping.m
+++ b/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/SyntheticTyping.m
@@ -1,3 +1,7 @@
+% SPDX-FileCopyrightText: 2024 DeviceLab
+%
+% SPDX-License-Identifier: LicenseRef-maestro-runner
+
 #import "SyntheticTyping.h"
 #import <UIKit/UIKit.h>
 #import "PrivateHeaders/XCTest/XCSynthesizedEventRecord.h"

--- a/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/SyntheticTyping.m
+++ b/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/SyntheticTyping.m
@@ -1,4 +1,4 @@
-% SPDX-FileCopyrightText: 2024–2026 DeviceLab
+% SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 %
 % SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/SyntheticTyping.m
+++ b/drivers/ios/DevicelabIOSRunner/DevicelabIOSRunnerUITests/SyntheticTyping.m
@@ -1,4 +1,4 @@
-% SPDX-FileCopyrightText: 2024 DeviceLab
+% SPDX-FileCopyrightText: 2024–2026 DeviceLab
 %
 % SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/main.go
+++ b/main.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 // Package main is the entry point for maestro-runner CLI.
 package main
 

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/android.go
+++ b/pkg/cli/android.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/android.go
+++ b/pkg/cli/android.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package cli
 
 import (

--- a/pkg/cli/android.go
+++ b/pkg/cli/android.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/android.go
+++ b/pkg/cli/android.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 // Package cli provides the command-line interface for maestro-runner.
 package cli
 

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package cli
 
 import (

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/device.go
+++ b/pkg/cli/device.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package cli
 
 import (

--- a/pkg/cli/device.go
+++ b/pkg/cli/device.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/device.go
+++ b/pkg/cli/device.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/device.go
+++ b/pkg/cli/device.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/envfile.go
+++ b/pkg/cli/envfile.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/envfile.go
+++ b/pkg/cli/envfile.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package cli
 
 import (

--- a/pkg/cli/envfile.go
+++ b/pkg/cli/envfile.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/envfile.go
+++ b/pkg/cli/envfile.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/envfile_test.go
+++ b/pkg/cli/envfile_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/envfile_test.go
+++ b/pkg/cli/envfile_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package cli
 
 import (

--- a/pkg/cli/envfile_test.go
+++ b/pkg/cli/envfile_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/envfile_test.go
+++ b/pkg/cli/envfile_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/flutter_check.go
+++ b/pkg/cli/flutter_check.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/flutter_check.go
+++ b/pkg/cli/flutter_check.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package cli
 
 import (

--- a/pkg/cli/flutter_check.go
+++ b/pkg/cli/flutter_check.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/flutter_check.go
+++ b/pkg/cli/flutter_check.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/flutter_check_test.go
+++ b/pkg/cli/flutter_check_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/flutter_check_test.go
+++ b/pkg/cli/flutter_check_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package cli
 
 import (

--- a/pkg/cli/flutter_check_test.go
+++ b/pkg/cli/flutter_check_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/flutter_check_test.go
+++ b/pkg/cli/flutter_check_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/ios.go
+++ b/pkg/cli/ios.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/ios.go
+++ b/pkg/cli/ios.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package cli
 
 import (

--- a/pkg/cli/ios.go
+++ b/pkg/cli/ios.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/ios.go
+++ b/pkg/cli/ios.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/ios_devicelab.go
+++ b/pkg/cli/ios_devicelab.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/ios_devicelab.go
+++ b/pkg/cli/ios_devicelab.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package cli
 
 import (

--- a/pkg/cli/ios_devicelab.go
+++ b/pkg/cli/ios_devicelab.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/ios_devicelab.go
+++ b/pkg/cli/ios_devicelab.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/test.go
+++ b/pkg/cli/test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package cli
 
 import (

--- a/pkg/cli/test.go
+++ b/pkg/cli/test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/test.go
+++ b/pkg/cli/test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/test.go
+++ b/pkg/cli/test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/test_unified_output.go
+++ b/pkg/cli/test_unified_output.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/test_unified_output.go
+++ b/pkg/cli/test_unified_output.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package cli
 
 import (

--- a/pkg/cli/test_unified_output.go
+++ b/pkg/cli/test_unified_output.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/test_unified_output.go
+++ b/pkg/cli/test_unified_output.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/update.go
+++ b/pkg/cli/update.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/update.go
+++ b/pkg/cli/update.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package cli
 
 import (

--- a/pkg/cli/update.go
+++ b/pkg/cli/update.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/update.go
+++ b/pkg/cli/update.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/wda.go
+++ b/pkg/cli/wda.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/wda.go
+++ b/pkg/cli/wda.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package cli
 
 import (

--- a/pkg/cli/wda.go
+++ b/pkg/cli/wda.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/wda.go
+++ b/pkg/cli/wda.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/web.go
+++ b/pkg/cli/web.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/web.go
+++ b/pkg/cli/web.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package cli
 
 import (

--- a/pkg/cli/web.go
+++ b/pkg/cli/web.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cli/web.go
+++ b/pkg/cli/web.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cloud/composite.go
+++ b/pkg/cloud/composite.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cloud/composite.go
+++ b/pkg/cloud/composite.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cloud/composite.go
+++ b/pkg/cloud/composite.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 // Package cloud — composite provider.
 //
 // Composite fans every Provider hook out to several providers at once, so a

--- a/pkg/cloud/composite.go
+++ b/pkg/cloud/composite.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cloud/composite_test.go
+++ b/pkg/cloud/composite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cloud/composite_test.go
+++ b/pkg/cloud/composite_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package cloud
 
 import (

--- a/pkg/cloud/composite_test.go
+++ b/pkg/cloud/composite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cloud/composite_test.go
+++ b/pkg/cloud/composite_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cloud/example_provider.go
+++ b/pkg/cloud/example_provider.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cloud/example_provider.go
+++ b/pkg/cloud/example_provider.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 // This file is a skeleton for adding a new cloud provider.
 // Copy this file, rename it, and implement the TODOs.
 //

--- a/pkg/cloud/example_provider.go
+++ b/pkg/cloud/example_provider.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cloud/example_provider.go
+++ b/pkg/cloud/example_provider.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cloud/loopback.go
+++ b/pkg/cloud/loopback.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cloud/loopback.go
+++ b/pkg/cloud/loopback.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cloud/loopback.go
+++ b/pkg/cloud/loopback.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cloud/loopback.go
+++ b/pkg/cloud/loopback.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 // Package cloud — loopback provider.
 //
 // The loopback provider is a debug-only stand-in that mimics a cloud provider

--- a/pkg/cloud/loopback_test.go
+++ b/pkg/cloud/loopback_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cloud/loopback_test.go
+++ b/pkg/cloud/loopback_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package cloud
 
 import (

--- a/pkg/cloud/loopback_test.go
+++ b/pkg/cloud/loopback_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cloud/loopback_test.go
+++ b/pkg/cloud/loopback_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cloud/provider.go
+++ b/pkg/cloud/provider.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cloud/provider.go
+++ b/pkg/cloud/provider.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cloud/provider.go
+++ b/pkg/cloud/provider.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 // Package cloud provides an abstraction for cloud device providers
 // (Sauce Labs, BrowserStack, LambdaTest, TestingBot, etc.).
 //

--- a/pkg/cloud/provider.go
+++ b/pkg/cloud/provider.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cloud/provider_test.go
+++ b/pkg/cloud/provider_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cloud/provider_test.go
+++ b/pkg/cloud/provider_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cloud/provider_test.go
+++ b/pkg/cloud/provider_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package cloud
 
 import "testing"

--- a/pkg/cloud/provider_test.go
+++ b/pkg/cloud/provider_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cloud/saucelabs.go
+++ b/pkg/cloud/saucelabs.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cloud/saucelabs.go
+++ b/pkg/cloud/saucelabs.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package cloud
 
 import (

--- a/pkg/cloud/saucelabs.go
+++ b/pkg/cloud/saucelabs.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cloud/saucelabs.go
+++ b/pkg/cloud/saucelabs.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cloud/saucelabs_test.go
+++ b/pkg/cloud/saucelabs_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cloud/saucelabs_test.go
+++ b/pkg/cloud/saucelabs_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package cloud
 
 import (

--- a/pkg/cloud/saucelabs_test.go
+++ b/pkg/cloud/saucelabs_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cloud/saucelabs_test.go
+++ b/pkg/cloud/saucelabs_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cloud/session_export.go
+++ b/pkg/cloud/session_export.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cloud/session_export.go
+++ b/pkg/cloud/session_export.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cloud/session_export.go
+++ b/pkg/cloud/session_export.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 // Package cloud — Appium session exporter.
 //
 // SessionExporter is an always-on (opt-in) Provider that publishes the live

--- a/pkg/cloud/session_export.go
+++ b/pkg/cloud/session_export.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cloud/session_export_test.go
+++ b/pkg/cloud/session_export_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cloud/session_export_test.go
+++ b/pkg/cloud/session_export_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package cloud
 
 import (

--- a/pkg/cloud/session_export_test.go
+++ b/pkg/cloud/session_export_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/cloud/session_export_test.go
+++ b/pkg/cloud/session_export_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 // Package config handles configuration for maestro-runner.
 package config
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package config
 
 import (

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/config/home.go
+++ b/pkg/config/home.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/config/home.go
+++ b/pkg/config/home.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/config/home.go
+++ b/pkg/config/home.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package config
 
 import (

--- a/pkg/config/home.go
+++ b/pkg/config/home.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/config/home_test.go
+++ b/pkg/config/home_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/config/home_test.go
+++ b/pkg/config/home_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/config/home_test.go
+++ b/pkg/config/home_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package config
 
 import (

--- a/pkg/config/home_test.go
+++ b/pkg/config/home_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/artifacts.go
+++ b/pkg/core/artifacts.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/artifacts.go
+++ b/pkg/core/artifacts.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 // Package core provides the execution model types for maestro-runner.
 package core
 

--- a/pkg/core/artifacts.go
+++ b/pkg/core/artifacts.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/artifacts.go
+++ b/pkg/core/artifacts.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/artifacts_test.go
+++ b/pkg/core/artifacts_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package core
 
 import (

--- a/pkg/core/artifacts_test.go
+++ b/pkg/core/artifacts_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/artifacts_test.go
+++ b/pkg/core/artifacts_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/artifacts_test.go
+++ b/pkg/core/artifacts_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/driver.go
+++ b/pkg/core/driver.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/driver.go
+++ b/pkg/core/driver.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package core
 
 import (

--- a/pkg/core/driver.go
+++ b/pkg/core/driver.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/driver.go
+++ b/pkg/core/driver.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/driver_test.go
+++ b/pkg/core/driver_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/driver_test.go
+++ b/pkg/core/driver_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package core
 
 import (

--- a/pkg/core/driver_test.go
+++ b/pkg/core/driver_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/driver_test.go
+++ b/pkg/core/driver_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/element.go
+++ b/pkg/core/element.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/element.go
+++ b/pkg/core/element.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package core
 
 // Element is an abstraction over native (UIAutomator2) and web (Rod/CDP) elements.

--- a/pkg/core/element.go
+++ b/pkg/core/element.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/element.go
+++ b/pkg/core/element.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/errors.go
+++ b/pkg/core/errors.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package core
 
 import (

--- a/pkg/core/errors.go
+++ b/pkg/core/errors.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/errors.go
+++ b/pkg/core/errors.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/errors.go
+++ b/pkg/core/errors.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/errors_test.go
+++ b/pkg/core/errors_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package core
 
 import (

--- a/pkg/core/errors_test.go
+++ b/pkg/core/errors_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/errors_test.go
+++ b/pkg/core/errors_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/errors_test.go
+++ b/pkg/core/errors_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/imagediff.go
+++ b/pkg/core/imagediff.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/imagediff.go
+++ b/pkg/core/imagediff.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package core
 
 import (

--- a/pkg/core/imagediff.go
+++ b/pkg/core/imagediff.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/imagediff.go
+++ b/pkg/core/imagediff.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/imagediff_test.go
+++ b/pkg/core/imagediff_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/imagediff_test.go
+++ b/pkg/core/imagediff_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package core
 
 import (

--- a/pkg/core/imagediff_test.go
+++ b/pkg/core/imagediff_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/imagediff_test.go
+++ b/pkg/core/imagediff_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/point.go
+++ b/pkg/core/point.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/point.go
+++ b/pkg/core/point.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package core
 
 import (

--- a/pkg/core/point.go
+++ b/pkg/core/point.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/point.go
+++ b/pkg/core/point.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/point_test.go
+++ b/pkg/core/point_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/point_test.go
+++ b/pkg/core/point_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package core
 
 import (

--- a/pkg/core/point_test.go
+++ b/pkg/core/point_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/point_test.go
+++ b/pkg/core/point_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/random.go
+++ b/pkg/core/random.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/random.go
+++ b/pkg/core/random.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/random.go
+++ b/pkg/core/random.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package core
 
 import "math/rand"

--- a/pkg/core/random.go
+++ b/pkg/core/random.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/random_test.go
+++ b/pkg/core/random_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/random_test.go
+++ b/pkg/core/random_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package core
 
 import (

--- a/pkg/core/random_test.go
+++ b/pkg/core/random_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/random_test.go
+++ b/pkg/core/random_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/result.go
+++ b/pkg/core/result.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package core
 
 import (

--- a/pkg/core/result.go
+++ b/pkg/core/result.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/result.go
+++ b/pkg/core/result.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/result.go
+++ b/pkg/core/result.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/result_test.go
+++ b/pkg/core/result_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package core
 
 import (

--- a/pkg/core/result_test.go
+++ b/pkg/core/result_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/result_test.go
+++ b/pkg/core/result_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/result_test.go
+++ b/pkg/core/result_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/screenshot.go
+++ b/pkg/core/screenshot.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/screenshot.go
+++ b/pkg/core/screenshot.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package core
 
 import (

--- a/pkg/core/screenshot.go
+++ b/pkg/core/screenshot.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/screenshot.go
+++ b/pkg/core/screenshot.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/screenshot_test.go
+++ b/pkg/core/screenshot_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/screenshot_test.go
+++ b/pkg/core/screenshot_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package core
 
 import (

--- a/pkg/core/screenshot_test.go
+++ b/pkg/core/screenshot_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/screenshot_test.go
+++ b/pkg/core/screenshot_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/status.go
+++ b/pkg/core/status.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package core
 
 // StepStatus represents the execution status of a step

--- a/pkg/core/status.go
+++ b/pkg/core/status.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/status.go
+++ b/pkg/core/status.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/status.go
+++ b/pkg/core/status.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/status_test.go
+++ b/pkg/core/status_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package core
 
 import "testing"

--- a/pkg/core/status_test.go
+++ b/pkg/core/status_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/status_test.go
+++ b/pkg/core/status_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/core/status_test.go
+++ b/pkg/core/status_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/device/android.go
+++ b/pkg/device/android.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/device/android.go
+++ b/pkg/device/android.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/device/android.go
+++ b/pkg/device/android.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 // Package device provides Android device management via ADB.
 package device
 

--- a/pkg/device/android.go
+++ b/pkg/device/android.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/device/android_test.go
+++ b/pkg/device/android_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package device
 
 import (

--- a/pkg/device/android_test.go
+++ b/pkg/device/android_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/device/android_test.go
+++ b/pkg/device/android_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/device/android_test.go
+++ b/pkg/device/android_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/device/devicelab_driver.go
+++ b/pkg/device/devicelab_driver.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package device
 
 import (

--- a/pkg/device/devicelab_driver.go
+++ b/pkg/device/devicelab_driver.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/device/devicelab_driver.go
+++ b/pkg/device/devicelab_driver.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/device/devicelab_driver.go
+++ b/pkg/device/devicelab_driver.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/device/devicelab_driver_test.go
+++ b/pkg/device/devicelab_driver_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package device
 
 import (

--- a/pkg/device/devicelab_driver_test.go
+++ b/pkg/device/devicelab_driver_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/device/devicelab_driver_test.go
+++ b/pkg/device/devicelab_driver_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/device/devicelab_driver_test.go
+++ b/pkg/device/devicelab_driver_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/device/discover.go
+++ b/pkg/device/discover.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package device
 
 import (

--- a/pkg/device/discover.go
+++ b/pkg/device/discover.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/device/discover.go
+++ b/pkg/device/discover.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/device/discover.go
+++ b/pkg/device/discover.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/device/discover_test.go
+++ b/pkg/device/discover_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package device
 
 import (

--- a/pkg/device/discover_test.go
+++ b/pkg/device/discover_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/device/discover_test.go
+++ b/pkg/device/discover_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/device/discover_test.go
+++ b/pkg/device/discover_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/device/exec.go
+++ b/pkg/device/exec.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/device/exec.go
+++ b/pkg/device/exec.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/device/exec.go
+++ b/pkg/device/exec.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/device/exec.go
+++ b/pkg/device/exec.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package device
 
 import "os/exec"

--- a/pkg/device/exec_test.go
+++ b/pkg/device/exec_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package device
 
 import (

--- a/pkg/device/exec_test.go
+++ b/pkg/device/exec_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/device/exec_test.go
+++ b/pkg/device/exec_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/device/exec_test.go
+++ b/pkg/device/exec_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/device/uiautomator.go
+++ b/pkg/device/uiautomator.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package device
 
 import (

--- a/pkg/device/uiautomator.go
+++ b/pkg/device/uiautomator.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/device/uiautomator.go
+++ b/pkg/device/uiautomator.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/device/uiautomator.go
+++ b/pkg/device/uiautomator.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/device/uiautomator_test.go
+++ b/pkg/device/uiautomator_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package device
 
 import (

--- a/pkg/device/uiautomator_test.go
+++ b/pkg/device/uiautomator_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/device/uiautomator_test.go
+++ b/pkg/device/uiautomator_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/device/uiautomator_test.go
+++ b/pkg/device/uiautomator_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/appium/client.go
+++ b/pkg/driver/appium/client.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/appium/client.go
+++ b/pkg/driver/appium/client.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/appium/client.go
+++ b/pkg/driver/appium/client.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 // Package appium implements core.Driver using Appium server via W3C WebDriver protocol.
 package appium
 

--- a/pkg/driver/appium/client.go
+++ b/pkg/driver/appium/client.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/appium/client_test.go
+++ b/pkg/driver/appium/client_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/appium/client_test.go
+++ b/pkg/driver/appium/client_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/appium/client_test.go
+++ b/pkg/driver/appium/client_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package appium
 
 import (

--- a/pkg/driver/appium/client_test.go
+++ b/pkg/driver/appium/client_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/appium/commands.go
+++ b/pkg/driver/appium/commands.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/appium/commands.go
+++ b/pkg/driver/appium/commands.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/appium/commands.go
+++ b/pkg/driver/appium/commands.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package appium
 
 import (

--- a/pkg/driver/appium/commands.go
+++ b/pkg/driver/appium/commands.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/appium/commands_test.go
+++ b/pkg/driver/appium/commands_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/appium/commands_test.go
+++ b/pkg/driver/appium/commands_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/appium/commands_test.go
+++ b/pkg/driver/appium/commands_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package appium
 
 import (

--- a/pkg/driver/appium/commands_test.go
+++ b/pkg/driver/appium/commands_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/appium/driver.go
+++ b/pkg/driver/appium/driver.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/appium/driver.go
+++ b/pkg/driver/appium/driver.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/appium/driver.go
+++ b/pkg/driver/appium/driver.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package appium
 
 import (

--- a/pkg/driver/appium/driver.go
+++ b/pkg/driver/appium/driver.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/appium/driver_test.go
+++ b/pkg/driver/appium/driver_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/appium/driver_test.go
+++ b/pkg/driver/appium/driver_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/appium/driver_test.go
+++ b/pkg/driver/appium/driver_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package appium
 
 import (

--- a/pkg/driver/appium/driver_test.go
+++ b/pkg/driver/appium/driver_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/appium/pagesource.go
+++ b/pkg/driver/appium/pagesource.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/appium/pagesource.go
+++ b/pkg/driver/appium/pagesource.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/appium/pagesource.go
+++ b/pkg/driver/appium/pagesource.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package appium
 
 import (

--- a/pkg/driver/appium/pagesource.go
+++ b/pkg/driver/appium/pagesource.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/appium/pagesource_test.go
+++ b/pkg/driver/appium/pagesource_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/appium/pagesource_test.go
+++ b/pkg/driver/appium/pagesource_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/appium/pagesource_test.go
+++ b/pkg/driver/appium/pagesource_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package appium
 
 import (

--- a/pkg/driver/appium/pagesource_test.go
+++ b/pkg/driver/appium/pagesource_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/browser/cdp/actionable_test.go
+++ b/pkg/driver/browser/cdp/actionable_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/browser/cdp/actionable_test.go
+++ b/pkg/driver/browser/cdp/actionable_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/browser/cdp/actionable_test.go
+++ b/pkg/driver/browser/cdp/actionable_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package cdp
 
 import (

--- a/pkg/driver/browser/cdp/actionable_test.go
+++ b/pkg/driver/browser/cdp/actionable_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/browser/cdp/commands.go
+++ b/pkg/driver/browser/cdp/commands.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/browser/cdp/commands.go
+++ b/pkg/driver/browser/cdp/commands.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/browser/cdp/commands.go
+++ b/pkg/driver/browser/cdp/commands.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package cdp
 
 import (

--- a/pkg/driver/browser/cdp/commands.go
+++ b/pkg/driver/browser/cdp/commands.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/browser/cdp/commands_iframe_test.go
+++ b/pkg/driver/browser/cdp/commands_iframe_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/browser/cdp/commands_iframe_test.go
+++ b/pkg/driver/browser/cdp/commands_iframe_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/browser/cdp/commands_iframe_test.go
+++ b/pkg/driver/browser/cdp/commands_iframe_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package cdp
 
 import (

--- a/pkg/driver/browser/cdp/commands_iframe_test.go
+++ b/pkg/driver/browser/cdp/commands_iframe_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/browser/cdp/console_report_test.go
+++ b/pkg/driver/browser/cdp/console_report_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/browser/cdp/console_report_test.go
+++ b/pkg/driver/browser/cdp/console_report_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/browser/cdp/console_report_test.go
+++ b/pkg/driver/browser/cdp/console_report_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package cdp
 
 import (

--- a/pkg/driver/browser/cdp/console_report_test.go
+++ b/pkg/driver/browser/cdp/console_report_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/browser/cdp/driver.go
+++ b/pkg/driver/browser/cdp/driver.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/browser/cdp/driver.go
+++ b/pkg/driver/browser/cdp/driver.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/browser/cdp/driver.go
+++ b/pkg/driver/browser/cdp/driver.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package cdp
 
 import (

--- a/pkg/driver/browser/cdp/driver.go
+++ b/pkg/driver/browser/cdp/driver.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/browser/cdp/driver_test.go
+++ b/pkg/driver/browser/cdp/driver_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/browser/cdp/driver_test.go
+++ b/pkg/driver/browser/cdp/driver_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/browser/cdp/driver_test.go
+++ b/pkg/driver/browser/cdp/driver_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package cdp
 
 import (

--- a/pkg/driver/browser/cdp/driver_test.go
+++ b/pkg/driver/browser/cdp/driver_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/browser/cdp/finder.go
+++ b/pkg/driver/browser/cdp/finder.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/browser/cdp/finder.go
+++ b/pkg/driver/browser/cdp/finder.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/browser/cdp/finder.go
+++ b/pkg/driver/browser/cdp/finder.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package cdp
 
 import (

--- a/pkg/driver/browser/cdp/finder.go
+++ b/pkg/driver/browser/cdp/finder.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/browser/cdp/jshelper.go
+++ b/pkg/driver/browser/cdp/jshelper.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/browser/cdp/jshelper.go
+++ b/pkg/driver/browser/cdp/jshelper.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 // Package cdp provides a browser automation driver using Rod (go-rod/rod) + CDP.
 package cdp
 

--- a/pkg/driver/browser/cdp/jshelper.go
+++ b/pkg/driver/browser/cdp/jshelper.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/browser/cdp/jshelper.go
+++ b/pkg/driver/browser/cdp/jshelper.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/browser/cdp/jshelper.js
+++ b/pkg/driver/browser/cdp/jshelper.js
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/browser/cdp/jshelper.js
+++ b/pkg/driver/browser/cdp/jshelper.js
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/browser/cdp/jshelper.js
+++ b/pkg/driver/browser/cdp/jshelper.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 window.__maestro = {
   // Tracks how many cross-origin iframes _collectRoots skipped on the most
   // recent walk. Read by the Go side to surface a clear error when a query

--- a/pkg/driver/browser/cdp/jshelper.js
+++ b/pkg/driver/browser/cdp/jshelper.js
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/boundstappable_test.go
+++ b/pkg/driver/devicelab/boundstappable_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/boundstappable_test.go
+++ b/pkg/driver/devicelab/boundstappable_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package devicelab
 
 import (

--- a/pkg/driver/devicelab/boundstappable_test.go
+++ b/pkg/driver/devicelab/boundstappable_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/boundstappable_test.go
+++ b/pkg/driver/devicelab/boundstappable_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/browser_jshelper.js
+++ b/pkg/driver/devicelab/browser_jshelper.js
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/browser_jshelper.js
+++ b/pkg/driver/devicelab/browser_jshelper.js
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/browser_jshelper.js
+++ b/pkg/driver/devicelab/browser_jshelper.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 (function() {
   // Override alert/confirm/prompt — on page-level Chrome Android CDP connections,
   // a native dialog freezes ALL CDP commands including Page.handleJavaScriptDialog.

--- a/pkg/driver/devicelab/browser_jshelper.js
+++ b/pkg/driver/devicelab/browser_jshelper.js
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/commands.go
+++ b/pkg/driver/devicelab/commands.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/commands.go
+++ b/pkg/driver/devicelab/commands.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package devicelab
 
 import (

--- a/pkg/driver/devicelab/commands.go
+++ b/pkg/driver/devicelab/commands.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/commands.go
+++ b/pkg/driver/devicelab/commands.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/commands_helpers_test.go
+++ b/pkg/driver/devicelab/commands_helpers_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/commands_helpers_test.go
+++ b/pkg/driver/devicelab/commands_helpers_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package devicelab
 
 import (

--- a/pkg/driver/devicelab/commands_helpers_test.go
+++ b/pkg/driver/devicelab/commands_helpers_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/commands_helpers_test.go
+++ b/pkg/driver/devicelab/commands_helpers_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/commands_test.go
+++ b/pkg/driver/devicelab/commands_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/commands_test.go
+++ b/pkg/driver/devicelab/commands_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package devicelab
 
 import (

--- a/pkg/driver/devicelab/commands_test.go
+++ b/pkg/driver/devicelab/commands_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/commands_test.go
+++ b/pkg/driver/devicelab/commands_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/driver.go
+++ b/pkg/driver/devicelab/driver.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/driver.go
+++ b/pkg/driver/devicelab/driver.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 // Package devicelab provides Android automation driver using the DeviceLab Android Driver.
 // This is a WebSocket-based driver with on-device RPC for app lifecycle operations.
 // Unlike the UIAutomator2 HTTP driver, element taps are always coordinate-based

--- a/pkg/driver/devicelab/driver.go
+++ b/pkg/driver/devicelab/driver.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/driver.go
+++ b/pkg/driver/devicelab/driver.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/jshelpers.go
+++ b/pkg/driver/devicelab/jshelpers.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/jshelpers.go
+++ b/pkg/driver/devicelab/jshelpers.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/jshelpers.go
+++ b/pkg/driver/devicelab/jshelpers.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/jshelpers.go
+++ b/pkg/driver/devicelab/jshelpers.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package devicelab
 
 import _ "embed"

--- a/pkg/driver/devicelab/keyboard.go
+++ b/pkg/driver/devicelab/keyboard.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/keyboard.go
+++ b/pkg/driver/devicelab/keyboard.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package devicelab
 
 import (

--- a/pkg/driver/devicelab/keyboard.go
+++ b/pkg/driver/devicelab/keyboard.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/keyboard.go
+++ b/pkg/driver/devicelab/keyboard.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/lazyretry_test.go
+++ b/pkg/driver/devicelab/lazyretry_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/lazyretry_test.go
+++ b/pkg/driver/devicelab/lazyretry_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package devicelab
 
 import (

--- a/pkg/driver/devicelab/lazyretry_test.go
+++ b/pkg/driver/devicelab/lazyretry_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/lazyretry_test.go
+++ b/pkg/driver/devicelab/lazyretry_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/native_element.go
+++ b/pkg/driver/devicelab/native_element.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/native_element.go
+++ b/pkg/driver/devicelab/native_element.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package devicelab
 
 import (

--- a/pkg/driver/devicelab/native_element.go
+++ b/pkg/driver/devicelab/native_element.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/native_element.go
+++ b/pkg/driver/devicelab/native_element.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/pagesource.go
+++ b/pkg/driver/devicelab/pagesource.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/pagesource.go
+++ b/pkg/driver/devicelab/pagesource.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package devicelab
 
 import (

--- a/pkg/driver/devicelab/pagesource.go
+++ b/pkg/driver/devicelab/pagesource.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/pagesource.go
+++ b/pkg/driver/devicelab/pagesource.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/pagesource_helpers_test.go
+++ b/pkg/driver/devicelab/pagesource_helpers_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/pagesource_helpers_test.go
+++ b/pkg/driver/devicelab/pagesource_helpers_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package devicelab
 
 import (

--- a/pkg/driver/devicelab/pagesource_helpers_test.go
+++ b/pkg/driver/devicelab/pagesource_helpers_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/pagesource_helpers_test.go
+++ b/pkg/driver/devicelab/pagesource_helpers_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/physicalscreen_test.go
+++ b/pkg/driver/devicelab/physicalscreen_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/physicalscreen_test.go
+++ b/pkg/driver/devicelab/physicalscreen_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package devicelab
 
 import (

--- a/pkg/driver/devicelab/physicalscreen_test.go
+++ b/pkg/driver/devicelab/physicalscreen_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/physicalscreen_test.go
+++ b/pkg/driver/devicelab/physicalscreen_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/web_element.go
+++ b/pkg/driver/devicelab/web_element.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/web_element.go
+++ b/pkg/driver/devicelab/web_element.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package devicelab
 
 import (

--- a/pkg/driver/devicelab/web_element.go
+++ b/pkg/driver/devicelab/web_element.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/web_element.go
+++ b/pkg/driver/devicelab/web_element.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/webview.go
+++ b/pkg/driver/devicelab/webview.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/webview.go
+++ b/pkg/driver/devicelab/webview.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package devicelab
 
 import (

--- a/pkg/driver/devicelab/webview.go
+++ b/pkg/driver/devicelab/webview.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/webview.go
+++ b/pkg/driver/devicelab/webview.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/webview_jshelper.js
+++ b/pkg/driver/devicelab/webview_jshelper.js
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/webview_jshelper.js
+++ b/pkg/driver/devicelab/webview_jshelper.js
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 window.__maestro = {
   findByText: function(text) {
     var lower = text.toLowerCase();

--- a/pkg/driver/devicelab/webview_jshelper.js
+++ b/pkg/driver/devicelab/webview_jshelper.js
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab/webview_jshelper.js
+++ b/pkg/driver/devicelab/webview_jshelper.js
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab_ios/build.go
+++ b/pkg/driver/devicelab_ios/build.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab_ios/build.go
+++ b/pkg/driver/devicelab_ios/build.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab_ios/build.go
+++ b/pkg/driver/devicelab_ios/build.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package devicelab_ios
 
 import (

--- a/pkg/driver/devicelab_ios/build.go
+++ b/pkg/driver/devicelab_ios/build.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab_ios/client.go
+++ b/pkg/driver/devicelab_ios/client.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab_ios/client.go
+++ b/pkg/driver/devicelab_ios/client.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab_ios/client.go
+++ b/pkg/driver/devicelab_ios/client.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package devicelab_ios
 
 import (

--- a/pkg/driver/devicelab_ios/client.go
+++ b/pkg/driver/devicelab_ios/client.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab_ios/commands.go
+++ b/pkg/driver/devicelab_ios/commands.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab_ios/commands.go
+++ b/pkg/driver/devicelab_ios/commands.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab_ios/commands.go
+++ b/pkg/driver/devicelab_ios/commands.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package devicelab_ios
 
 import (

--- a/pkg/driver/devicelab_ios/commands.go
+++ b/pkg/driver/devicelab_ios/commands.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab_ios/driver.go
+++ b/pkg/driver/devicelab_ios/driver.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab_ios/driver.go
+++ b/pkg/driver/devicelab_ios/driver.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab_ios/driver.go
+++ b/pkg/driver/devicelab_ios/driver.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package devicelab_ios
 
 import (

--- a/pkg/driver/devicelab_ios/driver.go
+++ b/pkg/driver/devicelab_ios/driver.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab_ios/pagesource.go
+++ b/pkg/driver/devicelab_ios/pagesource.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab_ios/pagesource.go
+++ b/pkg/driver/devicelab_ios/pagesource.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab_ios/pagesource.go
+++ b/pkg/driver/devicelab_ios/pagesource.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package devicelab_ios
 
 import (

--- a/pkg/driver/devicelab_ios/pagesource.go
+++ b/pkg/driver/devicelab_ios/pagesource.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab_ios/setup.go
+++ b/pkg/driver/devicelab_ios/setup.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab_ios/setup.go
+++ b/pkg/driver/devicelab_ios/setup.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab_ios/setup.go
+++ b/pkg/driver/devicelab_ios/setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package devicelab_ios
 
 import (

--- a/pkg/driver/devicelab_ios/setup.go
+++ b/pkg/driver/devicelab_ios/setup.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab_ios/simctl.go
+++ b/pkg/driver/devicelab_ios/simctl.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab_ios/simctl.go
+++ b/pkg/driver/devicelab_ios/simctl.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab_ios/simctl.go
+++ b/pkg/driver/devicelab_ios/simctl.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package devicelab_ios
 
 import (

--- a/pkg/driver/devicelab_ios/simctl.go
+++ b/pkg/driver/devicelab_ios/simctl.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab_ios/types.go
+++ b/pkg/driver/devicelab_ios/types.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab_ios/types.go
+++ b/pkg/driver/devicelab_ios/types.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/devicelab_ios/types.go
+++ b/pkg/driver/devicelab_ios/types.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 // Package devicelab_ios provides the Go client for the devicelab-ios-runner
 // XCUITest-based iOS driver. The runner source lives at
 // /Users/omnarayan/work/support-tools/devicelab-ios-runner and is a verbatim

--- a/pkg/driver/devicelab_ios/types.go
+++ b/pkg/driver/devicelab_ios/types.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/mock/mock.go
+++ b/pkg/driver/mock/mock.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/mock/mock.go
+++ b/pkg/driver/mock/mock.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/mock/mock.go
+++ b/pkg/driver/mock/mock.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 // Package mock provides a mock driver for testing without a real device.
 package mock
 

--- a/pkg/driver/mock/mock.go
+++ b/pkg/driver/mock/mock.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/mock/mock_test.go
+++ b/pkg/driver/mock/mock_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/mock/mock_test.go
+++ b/pkg/driver/mock/mock_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package mock
 
 import (

--- a/pkg/driver/mock/mock_test.go
+++ b/pkg/driver/mock/mock_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/mock/mock_test.go
+++ b/pkg/driver/mock/mock_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/uiautomator2/commands.go
+++ b/pkg/driver/uiautomator2/commands.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/uiautomator2/commands.go
+++ b/pkg/driver/uiautomator2/commands.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/uiautomator2/commands.go
+++ b/pkg/driver/uiautomator2/commands.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package uiautomator2
 
 import (

--- a/pkg/driver/uiautomator2/commands.go
+++ b/pkg/driver/uiautomator2/commands.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/uiautomator2/commands_test.go
+++ b/pkg/driver/uiautomator2/commands_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/uiautomator2/commands_test.go
+++ b/pkg/driver/uiautomator2/commands_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/uiautomator2/commands_test.go
+++ b/pkg/driver/uiautomator2/commands_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package uiautomator2
 
 import (

--- a/pkg/driver/uiautomator2/commands_test.go
+++ b/pkg/driver/uiautomator2/commands_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/uiautomator2/driver.go
+++ b/pkg/driver/uiautomator2/driver.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 // Package uiautomator2 provides Android automation driver using UIAutomator2 server.
 package uiautomator2
 

--- a/pkg/driver/uiautomator2/driver.go
+++ b/pkg/driver/uiautomator2/driver.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/uiautomator2/driver.go
+++ b/pkg/driver/uiautomator2/driver.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/uiautomator2/driver.go
+++ b/pkg/driver/uiautomator2/driver.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/uiautomator2/driver_test.go
+++ b/pkg/driver/uiautomator2/driver_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/uiautomator2/driver_test.go
+++ b/pkg/driver/uiautomator2/driver_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/uiautomator2/driver_test.go
+++ b/pkg/driver/uiautomator2/driver_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package uiautomator2
 
 import (

--- a/pkg/driver/uiautomator2/driver_test.go
+++ b/pkg/driver/uiautomator2/driver_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/uiautomator2/keyboard.go
+++ b/pkg/driver/uiautomator2/keyboard.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/uiautomator2/keyboard.go
+++ b/pkg/driver/uiautomator2/keyboard.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/uiautomator2/keyboard.go
+++ b/pkg/driver/uiautomator2/keyboard.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package uiautomator2
 
 import (

--- a/pkg/driver/uiautomator2/keyboard.go
+++ b/pkg/driver/uiautomator2/keyboard.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/uiautomator2/keyboard_test.go
+++ b/pkg/driver/uiautomator2/keyboard_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/uiautomator2/keyboard_test.go
+++ b/pkg/driver/uiautomator2/keyboard_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/uiautomator2/keyboard_test.go
+++ b/pkg/driver/uiautomator2/keyboard_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package uiautomator2
 
 import (

--- a/pkg/driver/uiautomator2/keyboard_test.go
+++ b/pkg/driver/uiautomator2/keyboard_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/uiautomator2/pagesource.go
+++ b/pkg/driver/uiautomator2/pagesource.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/uiautomator2/pagesource.go
+++ b/pkg/driver/uiautomator2/pagesource.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/uiautomator2/pagesource.go
+++ b/pkg/driver/uiautomator2/pagesource.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package uiautomator2
 
 import (

--- a/pkg/driver/uiautomator2/pagesource.go
+++ b/pkg/driver/uiautomator2/pagesource.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/uiautomator2/pagesource_test.go
+++ b/pkg/driver/uiautomator2/pagesource_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/uiautomator2/pagesource_test.go
+++ b/pkg/driver/uiautomator2/pagesource_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/uiautomator2/pagesource_test.go
+++ b/pkg/driver/uiautomator2/pagesource_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package uiautomator2
 
 import (

--- a/pkg/driver/uiautomator2/pagesource_test.go
+++ b/pkg/driver/uiautomator2/pagesource_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/wda/client.go
+++ b/pkg/driver/wda/client.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/wda/client.go
+++ b/pkg/driver/wda/client.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 // Package wda provides WebDriverAgent client for iOS automation.
 package wda
 

--- a/pkg/driver/wda/client.go
+++ b/pkg/driver/wda/client.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/wda/client.go
+++ b/pkg/driver/wda/client.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/wda/client_test.go
+++ b/pkg/driver/wda/client_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/wda/client_test.go
+++ b/pkg/driver/wda/client_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/wda/client_test.go
+++ b/pkg/driver/wda/client_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package wda
 
 import (

--- a/pkg/driver/wda/client_test.go
+++ b/pkg/driver/wda/client_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/wda/commands.go
+++ b/pkg/driver/wda/commands.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/wda/commands.go
+++ b/pkg/driver/wda/commands.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/wda/commands.go
+++ b/pkg/driver/wda/commands.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package wda
 
 import (

--- a/pkg/driver/wda/commands.go
+++ b/pkg/driver/wda/commands.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/wda/commands_test.go
+++ b/pkg/driver/wda/commands_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/wda/commands_test.go
+++ b/pkg/driver/wda/commands_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/wda/commands_test.go
+++ b/pkg/driver/wda/commands_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package wda
 
 import (

--- a/pkg/driver/wda/commands_test.go
+++ b/pkg/driver/wda/commands_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/wda/crashloop_test.go
+++ b/pkg/driver/wda/crashloop_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/wda/crashloop_test.go
+++ b/pkg/driver/wda/crashloop_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/wda/crashloop_test.go
+++ b/pkg/driver/wda/crashloop_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package wda
 
 import (

--- a/pkg/driver/wda/crashloop_test.go
+++ b/pkg/driver/wda/crashloop_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/wda/driver.go
+++ b/pkg/driver/wda/driver.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/wda/driver.go
+++ b/pkg/driver/wda/driver.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/wda/driver.go
+++ b/pkg/driver/wda/driver.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package wda
 
 import (

--- a/pkg/driver/wda/driver.go
+++ b/pkg/driver/wda/driver.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/wda/driver_test.go
+++ b/pkg/driver/wda/driver_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/wda/driver_test.go
+++ b/pkg/driver/wda/driver_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/wda/driver_test.go
+++ b/pkg/driver/wda/driver_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package wda
 
 import (

--- a/pkg/driver/wda/driver_test.go
+++ b/pkg/driver/wda/driver_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/wda/exec.go
+++ b/pkg/driver/wda/exec.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/wda/exec.go
+++ b/pkg/driver/wda/exec.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/wda/exec.go
+++ b/pkg/driver/wda/exec.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package wda
 
 import "os/exec"

--- a/pkg/driver/wda/exec.go
+++ b/pkg/driver/wda/exec.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/wda/pagesource.go
+++ b/pkg/driver/wda/pagesource.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/wda/pagesource.go
+++ b/pkg/driver/wda/pagesource.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/wda/pagesource.go
+++ b/pkg/driver/wda/pagesource.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package wda
 
 import (

--- a/pkg/driver/wda/pagesource.go
+++ b/pkg/driver/wda/pagesource.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/wda/pagesource_test.go
+++ b/pkg/driver/wda/pagesource_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/wda/pagesource_test.go
+++ b/pkg/driver/wda/pagesource_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/wda/pagesource_test.go
+++ b/pkg/driver/wda/pagesource_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package wda
 
 import (

--- a/pkg/driver/wda/pagesource_test.go
+++ b/pkg/driver/wda/pagesource_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/wda/runner.go
+++ b/pkg/driver/wda/runner.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/wda/runner.go
+++ b/pkg/driver/wda/runner.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/wda/runner.go
+++ b/pkg/driver/wda/runner.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package wda
 
 import (

--- a/pkg/driver/wda/runner.go
+++ b/pkg/driver/wda/runner.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/wda/runner_test.go
+++ b/pkg/driver/wda/runner_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/wda/runner_test.go
+++ b/pkg/driver/wda/runner_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/wda/runner_test.go
+++ b/pkg/driver/wda/runner_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package wda
 
 import (

--- a/pkg/driver/wda/runner_test.go
+++ b/pkg/driver/wda/runner_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/wda/setup.go
+++ b/pkg/driver/wda/setup.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/wda/setup.go
+++ b/pkg/driver/wda/setup.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/driver/wda/setup.go
+++ b/pkg/driver/wda/setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package wda
 
 import (

--- a/pkg/driver/wda/setup.go
+++ b/pkg/driver/wda/setup.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/emulator/android.go
+++ b/pkg/emulator/android.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/emulator/android.go
+++ b/pkg/emulator/android.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/emulator/android.go
+++ b/pkg/emulator/android.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package emulator
 
 import (

--- a/pkg/emulator/android.go
+++ b/pkg/emulator/android.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/emulator/android_test.go
+++ b/pkg/emulator/android_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/emulator/android_test.go
+++ b/pkg/emulator/android_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/emulator/android_test.go
+++ b/pkg/emulator/android_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package emulator
 
 import (

--- a/pkg/emulator/android_test.go
+++ b/pkg/emulator/android_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/emulator/exec.go
+++ b/pkg/emulator/exec.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/emulator/exec.go
+++ b/pkg/emulator/exec.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/emulator/exec.go
+++ b/pkg/emulator/exec.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package emulator
 
 import "os/exec"

--- a/pkg/emulator/exec.go
+++ b/pkg/emulator/exec.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/emulator/exec_test.go
+++ b/pkg/emulator/exec_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/emulator/exec_test.go
+++ b/pkg/emulator/exec_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/emulator/exec_test.go
+++ b/pkg/emulator/exec_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package emulator
 
 import (

--- a/pkg/emulator/exec_test.go
+++ b/pkg/emulator/exec_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/emulator/manager.go
+++ b/pkg/emulator/manager.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/emulator/manager.go
+++ b/pkg/emulator/manager.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/emulator/manager.go
+++ b/pkg/emulator/manager.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package emulator
 
 import (

--- a/pkg/emulator/manager.go
+++ b/pkg/emulator/manager.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/emulator/types.go
+++ b/pkg/emulator/types.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/emulator/types.go
+++ b/pkg/emulator/types.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/emulator/types.go
+++ b/pkg/emulator/types.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package emulator
 
 import (

--- a/pkg/emulator/types.go
+++ b/pkg/emulator/types.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/executor/convert.go
+++ b/pkg/executor/convert.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package executor
 
 import (

--- a/pkg/executor/convert.go
+++ b/pkg/executor/convert.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/executor/convert.go
+++ b/pkg/executor/convert.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/executor/convert.go
+++ b/pkg/executor/convert.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/executor/convert_test.go
+++ b/pkg/executor/convert_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/executor/convert_test.go
+++ b/pkg/executor/convert_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package executor
 
 import (

--- a/pkg/executor/convert_test.go
+++ b/pkg/executor/convert_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/executor/convert_test.go
+++ b/pkg/executor/convert_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/executor/flow_runner.go
+++ b/pkg/executor/flow_runner.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package executor
 
 import (

--- a/pkg/executor/flow_runner.go
+++ b/pkg/executor/flow_runner.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/executor/flow_runner.go
+++ b/pkg/executor/flow_runner.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/executor/flow_runner.go
+++ b/pkg/executor/flow_runner.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/executor/flow_runner_console_test.go
+++ b/pkg/executor/flow_runner_console_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/executor/flow_runner_console_test.go
+++ b/pkg/executor/flow_runner_console_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package executor
 
 import (

--- a/pkg/executor/flow_runner_console_test.go
+++ b/pkg/executor/flow_runner_console_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/executor/flow_runner_console_test.go
+++ b/pkg/executor/flow_runner_console_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/executor/parallel.go
+++ b/pkg/executor/parallel.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/executor/parallel.go
+++ b/pkg/executor/parallel.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package executor
 
 import (

--- a/pkg/executor/parallel.go
+++ b/pkg/executor/parallel.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/executor/parallel.go
+++ b/pkg/executor/parallel.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/executor/parallel_test.go
+++ b/pkg/executor/parallel_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/executor/parallel_test.go
+++ b/pkg/executor/parallel_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package executor
 
 import (

--- a/pkg/executor/parallel_test.go
+++ b/pkg/executor/parallel_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/executor/parallel_test.go
+++ b/pkg/executor/parallel_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/executor/runner.go
+++ b/pkg/executor/runner.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/executor/runner.go
+++ b/pkg/executor/runner.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/executor/runner.go
+++ b/pkg/executor/runner.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 // Package executor orchestrates flow execution, connecting drivers to reports.
 package executor
 

--- a/pkg/executor/runner.go
+++ b/pkg/executor/runner.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/executor/runner_test.go
+++ b/pkg/executor/runner_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package executor
 
 import (

--- a/pkg/executor/runner_test.go
+++ b/pkg/executor/runner_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/executor/runner_test.go
+++ b/pkg/executor/runner_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/executor/runner_test.go
+++ b/pkg/executor/runner_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/executor/scripting.go
+++ b/pkg/executor/scripting.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package executor
 
 import (

--- a/pkg/executor/scripting.go
+++ b/pkg/executor/scripting.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/executor/scripting.go
+++ b/pkg/executor/scripting.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/executor/scripting.go
+++ b/pkg/executor/scripting.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/executor/scripting_test.go
+++ b/pkg/executor/scripting_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package executor
 
 import (

--- a/pkg/executor/scripting_test.go
+++ b/pkg/executor/scripting_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/executor/scripting_test.go
+++ b/pkg/executor/scripting_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/executor/scripting_test.go
+++ b/pkg/executor/scripting_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/executor/tap_options.go
+++ b/pkg/executor/tap_options.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/executor/tap_options.go
+++ b/pkg/executor/tap_options.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package executor
 
 import (

--- a/pkg/executor/tap_options.go
+++ b/pkg/executor/tap_options.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/executor/tap_options.go
+++ b/pkg/executor/tap_options.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/executor/tap_options_test.go
+++ b/pkg/executor/tap_options_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/executor/tap_options_test.go
+++ b/pkg/executor/tap_options_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package executor
 
 import (

--- a/pkg/executor/tap_options_test.go
+++ b/pkg/executor/tap_options_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/executor/tap_options_test.go
+++ b/pkg/executor/tap_options_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flow/flow.go
+++ b/pkg/flow/flow.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 // Package flow handles parsing and representation of Maestro YAML flow files.
 package flow
 

--- a/pkg/flow/flow.go
+++ b/pkg/flow/flow.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flow/flow.go
+++ b/pkg/flow/flow.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flow/flow.go
+++ b/pkg/flow/flow.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flow/parser.go
+++ b/pkg/flow/parser.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 // Package flow handles parsing and representation of Maestro YAML flow files.
 package flow
 

--- a/pkg/flow/parser.go
+++ b/pkg/flow/parser.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flow/parser.go
+++ b/pkg/flow/parser.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flow/parser.go
+++ b/pkg/flow/parser.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flow/parser_test.go
+++ b/pkg/flow/parser_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flow/parser_test.go
+++ b/pkg/flow/parser_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flow/parser_test.go
+++ b/pkg/flow/parser_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package flow
 
 import (

--- a/pkg/flow/parser_test.go
+++ b/pkg/flow/parser_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flow/selector.go
+++ b/pkg/flow/selector.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 // Package flow handles parsing and representation of Maestro YAML flow files.
 package flow
 

--- a/pkg/flow/selector.go
+++ b/pkg/flow/selector.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flow/selector.go
+++ b/pkg/flow/selector.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flow/selector.go
+++ b/pkg/flow/selector.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flow/selector_test.go
+++ b/pkg/flow/selector_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flow/selector_test.go
+++ b/pkg/flow/selector_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flow/selector_test.go
+++ b/pkg/flow/selector_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package flow
 
 import (

--- a/pkg/flow/selector_test.go
+++ b/pkg/flow/selector_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flow/step.go
+++ b/pkg/flow/step.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 // Package flow handles parsing and representation of Maestro YAML flow files.
 package flow
 

--- a/pkg/flow/step.go
+++ b/pkg/flow/step.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flow/step.go
+++ b/pkg/flow/step.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flow/step.go
+++ b/pkg/flow/step.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flow/step_test.go
+++ b/pkg/flow/step_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package flow
 
 import "testing"

--- a/pkg/flow/step_test.go
+++ b/pkg/flow/step_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flow/step_test.go
+++ b/pkg/flow/step_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flow/step_test.go
+++ b/pkg/flow/step_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flutter/discovery.go
+++ b/pkg/flutter/discovery.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flutter/discovery.go
+++ b/pkg/flutter/discovery.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flutter/discovery.go
+++ b/pkg/flutter/discovery.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package flutter
 
 import (

--- a/pkg/flutter/discovery.go
+++ b/pkg/flutter/discovery.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flutter/discovery_iossim.go
+++ b/pkg/flutter/discovery_iossim.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flutter/discovery_iossim.go
+++ b/pkg/flutter/discovery_iossim.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flutter/discovery_iossim.go
+++ b/pkg/flutter/discovery_iossim.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package flutter
 
 import (

--- a/pkg/flutter/discovery_iossim.go
+++ b/pkg/flutter/discovery_iossim.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flutter/discovery_iossim_test.go
+++ b/pkg/flutter/discovery_iossim_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flutter/discovery_iossim_test.go
+++ b/pkg/flutter/discovery_iossim_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package flutter
 
 import "testing"

--- a/pkg/flutter/discovery_iossim_test.go
+++ b/pkg/flutter/discovery_iossim_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flutter/discovery_iossim_test.go
+++ b/pkg/flutter/discovery_iossim_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flutter/discovery_test.go
+++ b/pkg/flutter/discovery_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flutter/discovery_test.go
+++ b/pkg/flutter/discovery_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flutter/discovery_test.go
+++ b/pkg/flutter/discovery_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package flutter
 
 import (

--- a/pkg/flutter/discovery_test.go
+++ b/pkg/flutter/discovery_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flutter/semantics.go
+++ b/pkg/flutter/semantics.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 // Package flutter provides Flutter VM Service integration for element finding fallback.
 package flutter
 

--- a/pkg/flutter/semantics.go
+++ b/pkg/flutter/semantics.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flutter/semantics.go
+++ b/pkg/flutter/semantics.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flutter/semantics.go
+++ b/pkg/flutter/semantics.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flutter/semantics_test.go
+++ b/pkg/flutter/semantics_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flutter/semantics_test.go
+++ b/pkg/flutter/semantics_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flutter/semantics_test.go
+++ b/pkg/flutter/semantics_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package flutter
 
 import (

--- a/pkg/flutter/semantics_test.go
+++ b/pkg/flutter/semantics_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flutter/vmservice.go
+++ b/pkg/flutter/vmservice.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flutter/vmservice.go
+++ b/pkg/flutter/vmservice.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flutter/vmservice.go
+++ b/pkg/flutter/vmservice.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package flutter
 
 import (

--- a/pkg/flutter/vmservice.go
+++ b/pkg/flutter/vmservice.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flutter/vmservice_test.go
+++ b/pkg/flutter/vmservice_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flutter/vmservice_test.go
+++ b/pkg/flutter/vmservice_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flutter/vmservice_test.go
+++ b/pkg/flutter/vmservice_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package flutter
 
 import (

--- a/pkg/flutter/vmservice_test.go
+++ b/pkg/flutter/vmservice_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flutter/widgettree.go
+++ b/pkg/flutter/widgettree.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flutter/widgettree.go
+++ b/pkg/flutter/widgettree.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flutter/widgettree.go
+++ b/pkg/flutter/widgettree.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package flutter
 
 import (

--- a/pkg/flutter/widgettree.go
+++ b/pkg/flutter/widgettree.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flutter/widgettree_test.go
+++ b/pkg/flutter/widgettree_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flutter/widgettree_test.go
+++ b/pkg/flutter/widgettree_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flutter/widgettree_test.go
+++ b/pkg/flutter/widgettree_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package flutter
 
 import (

--- a/pkg/flutter/widgettree_test.go
+++ b/pkg/flutter/widgettree_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flutter/wrapper.go
+++ b/pkg/flutter/wrapper.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flutter/wrapper.go
+++ b/pkg/flutter/wrapper.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flutter/wrapper.go
+++ b/pkg/flutter/wrapper.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package flutter
 
 import (

--- a/pkg/flutter/wrapper.go
+++ b/pkg/flutter/wrapper.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flutter/wrapper_test.go
+++ b/pkg/flutter/wrapper_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flutter/wrapper_test.go
+++ b/pkg/flutter/wrapper_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/flutter/wrapper_test.go
+++ b/pkg/flutter/wrapper_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package flutter
 
 import (

--- a/pkg/flutter/wrapper_test.go
+++ b/pkg/flutter/wrapper_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/jsengine/engine.go
+++ b/pkg/jsengine/engine.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 // Package jsengine provides JavaScript expression evaluation for Maestro flows.
 package jsengine
 

--- a/pkg/jsengine/engine.go
+++ b/pkg/jsengine/engine.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/jsengine/engine.go
+++ b/pkg/jsengine/engine.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/jsengine/engine.go
+++ b/pkg/jsengine/engine.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/jsengine/engine_test.go
+++ b/pkg/jsengine/engine_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/jsengine/engine_test.go
+++ b/pkg/jsengine/engine_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package jsengine
 
 import (

--- a/pkg/jsengine/engine_test.go
+++ b/pkg/jsengine/engine_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/jsengine/engine_test.go
+++ b/pkg/jsengine/engine_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/jsengine/http.go
+++ b/pkg/jsengine/http.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/jsengine/http.go
+++ b/pkg/jsengine/http.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package jsengine
 
 import (

--- a/pkg/jsengine/http.go
+++ b/pkg/jsengine/http.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/jsengine/http.go
+++ b/pkg/jsengine/http.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package logger
 
 import (

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package logger
 
 import (

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/maestro/adapter.go
+++ b/pkg/maestro/adapter.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/maestro/adapter.go
+++ b/pkg/maestro/adapter.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/maestro/adapter.go
+++ b/pkg/maestro/adapter.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package maestro
 
 import (

--- a/pkg/maestro/adapter.go
+++ b/pkg/maestro/adapter.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/maestro/adapter_test.go
+++ b/pkg/maestro/adapter_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/maestro/adapter_test.go
+++ b/pkg/maestro/adapter_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/maestro/adapter_test.go
+++ b/pkg/maestro/adapter_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package maestro
 
 import (

--- a/pkg/maestro/adapter_test.go
+++ b/pkg/maestro/adapter_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/maestro/client.go
+++ b/pkg/maestro/client.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/maestro/client.go
+++ b/pkg/maestro/client.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/maestro/client.go
+++ b/pkg/maestro/client.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package maestro
 
 import (

--- a/pkg/maestro/client.go
+++ b/pkg/maestro/client.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/maestro/client_test.go
+++ b/pkg/maestro/client_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/maestro/client_test.go
+++ b/pkg/maestro/client_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/maestro/client_test.go
+++ b/pkg/maestro/client_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package maestro
 
 import (

--- a/pkg/maestro/client_test.go
+++ b/pkg/maestro/client_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/maestro/events.go
+++ b/pkg/maestro/events.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/maestro/events.go
+++ b/pkg/maestro/events.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/maestro/events.go
+++ b/pkg/maestro/events.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package maestro
 
 import (

--- a/pkg/maestro/events.go
+++ b/pkg/maestro/events.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/maestro/events_test.go
+++ b/pkg/maestro/events_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/maestro/events_test.go
+++ b/pkg/maestro/events_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/maestro/events_test.go
+++ b/pkg/maestro/events_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package maestro
 
 import (

--- a/pkg/maestro/events_test.go
+++ b/pkg/maestro/events_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/maestro/protocol.go
+++ b/pkg/maestro/protocol.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/maestro/protocol.go
+++ b/pkg/maestro/protocol.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/maestro/protocol.go
+++ b/pkg/maestro/protocol.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 // Package maestro provides a WebSocket-based client for the DeviceLab on-device driver.
 // It implements the UIA2Client interface from pkg/driver/uiautomator2 using a
 // bidirectional WebSocket protocol instead of HTTP, enabling batched operations

--- a/pkg/maestro/protocol.go
+++ b/pkg/maestro/protocol.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/allure.go
+++ b/pkg/report/allure.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/allure.go
+++ b/pkg/report/allure.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/allure.go
+++ b/pkg/report/allure.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package report
 
 import (

--- a/pkg/report/allure.go
+++ b/pkg/report/allure.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/allure_test.go
+++ b/pkg/report/allure_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/allure_test.go
+++ b/pkg/report/allure_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/allure_test.go
+++ b/pkg/report/allure_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package report
 
 import (

--- a/pkg/report/allure_test.go
+++ b/pkg/report/allure_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/atomic.go
+++ b/pkg/report/atomic.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/atomic.go
+++ b/pkg/report/atomic.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/atomic.go
+++ b/pkg/report/atomic.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package report
 
 import (

--- a/pkg/report/atomic.go
+++ b/pkg/report/atomic.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/builder.go
+++ b/pkg/report/builder.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/builder.go
+++ b/pkg/report/builder.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/builder.go
+++ b/pkg/report/builder.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package report
 
 import (

--- a/pkg/report/builder.go
+++ b/pkg/report/builder.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/builder_test.go
+++ b/pkg/report/builder_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/builder_test.go
+++ b/pkg/report/builder_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/builder_test.go
+++ b/pkg/report/builder_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package report
 
 import (

--- a/pkg/report/builder_test.go
+++ b/pkg/report/builder_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/consumer.go
+++ b/pkg/report/consumer.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/consumer.go
+++ b/pkg/report/consumer.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package report
 
 import (

--- a/pkg/report/consumer.go
+++ b/pkg/report/consumer.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/consumer.go
+++ b/pkg/report/consumer.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/consumer_test.go
+++ b/pkg/report/consumer_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/consumer_test.go
+++ b/pkg/report/consumer_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/consumer_test.go
+++ b/pkg/report/consumer_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package report
 
 import (

--- a/pkg/report/consumer_test.go
+++ b/pkg/report/consumer_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/flow.go
+++ b/pkg/report/flow.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/flow.go
+++ b/pkg/report/flow.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/flow.go
+++ b/pkg/report/flow.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package report
 
 import (

--- a/pkg/report/flow.go
+++ b/pkg/report/flow.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/flow_test.go
+++ b/pkg/report/flow_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/flow_test.go
+++ b/pkg/report/flow_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/flow_test.go
+++ b/pkg/report/flow_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package report
 
 import (

--- a/pkg/report/flow_test.go
+++ b/pkg/report/flow_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/html.go
+++ b/pkg/report/html.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/html.go
+++ b/pkg/report/html.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/html.go
+++ b/pkg/report/html.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package report
 
 import (

--- a/pkg/report/html.go
+++ b/pkg/report/html.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/html_test.go
+++ b/pkg/report/html_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/html_test.go
+++ b/pkg/report/html_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/html_test.go
+++ b/pkg/report/html_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package report
 
 import (

--- a/pkg/report/html_test.go
+++ b/pkg/report/html_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/index.go
+++ b/pkg/report/index.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/index.go
+++ b/pkg/report/index.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/index.go
+++ b/pkg/report/index.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package report
 
 import (

--- a/pkg/report/index.go
+++ b/pkg/report/index.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/index_test.go
+++ b/pkg/report/index_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/index_test.go
+++ b/pkg/report/index_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package report
 
 import (

--- a/pkg/report/index_test.go
+++ b/pkg/report/index_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/index_test.go
+++ b/pkg/report/index_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/junit.go
+++ b/pkg/report/junit.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/junit.go
+++ b/pkg/report/junit.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/junit.go
+++ b/pkg/report/junit.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package report
 
 import (

--- a/pkg/report/junit.go
+++ b/pkg/report/junit.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/junit_test.go
+++ b/pkg/report/junit_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/junit_test.go
+++ b/pkg/report/junit_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/junit_test.go
+++ b/pkg/report/junit_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package report
 
 import (

--- a/pkg/report/junit_test.go
+++ b/pkg/report/junit_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/types.go
+++ b/pkg/report/types.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 // Package report provides JSON-based test reporting with real-time updates.
 //
 // Architecture:

--- a/pkg/report/types.go
+++ b/pkg/report/types.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/types.go
+++ b/pkg/report/types.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/types.go
+++ b/pkg/report/types.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/types_test.go
+++ b/pkg/report/types_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/types_test.go
+++ b/pkg/report/types_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package report
 
 import "testing"

--- a/pkg/report/types_test.go
+++ b/pkg/report/types_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/report/types_test.go
+++ b/pkg/report/types_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/simulator/exec.go
+++ b/pkg/simulator/exec.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/simulator/exec.go
+++ b/pkg/simulator/exec.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package simulator
 
 import "os/exec"

--- a/pkg/simulator/exec.go
+++ b/pkg/simulator/exec.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/simulator/exec.go
+++ b/pkg/simulator/exec.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/simulator/exec_test.go
+++ b/pkg/simulator/exec_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/simulator/exec_test.go
+++ b/pkg/simulator/exec_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package simulator
 
 import (

--- a/pkg/simulator/exec_test.go
+++ b/pkg/simulator/exec_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/simulator/exec_test.go
+++ b/pkg/simulator/exec_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/simulator/ios.go
+++ b/pkg/simulator/ios.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/simulator/ios.go
+++ b/pkg/simulator/ios.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package simulator
 
 import (

--- a/pkg/simulator/ios.go
+++ b/pkg/simulator/ios.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/simulator/ios.go
+++ b/pkg/simulator/ios.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/simulator/ios_test.go
+++ b/pkg/simulator/ios_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/simulator/ios_test.go
+++ b/pkg/simulator/ios_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package simulator
 
 import (

--- a/pkg/simulator/ios_test.go
+++ b/pkg/simulator/ios_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/simulator/ios_test.go
+++ b/pkg/simulator/ios_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/simulator/manager.go
+++ b/pkg/simulator/manager.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/simulator/manager.go
+++ b/pkg/simulator/manager.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package simulator
 
 import (

--- a/pkg/simulator/manager.go
+++ b/pkg/simulator/manager.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/simulator/manager.go
+++ b/pkg/simulator/manager.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/simulator/types.go
+++ b/pkg/simulator/types.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/simulator/types.go
+++ b/pkg/simulator/types.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package simulator
 
 import (

--- a/pkg/simulator/types.go
+++ b/pkg/simulator/types.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/simulator/types.go
+++ b/pkg/simulator/types.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/uiautomator2/client.go
+++ b/pkg/uiautomator2/client.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/uiautomator2/client.go
+++ b/pkg/uiautomator2/client.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/uiautomator2/client.go
+++ b/pkg/uiautomator2/client.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package uiautomator2
 
 import (

--- a/pkg/uiautomator2/client.go
+++ b/pkg/uiautomator2/client.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/uiautomator2/client_test.go
+++ b/pkg/uiautomator2/client_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/uiautomator2/client_test.go
+++ b/pkg/uiautomator2/client_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/uiautomator2/client_test.go
+++ b/pkg/uiautomator2/client_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package uiautomator2
 
 import (

--- a/pkg/uiautomator2/client_test.go
+++ b/pkg/uiautomator2/client_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/uiautomator2/device.go
+++ b/pkg/uiautomator2/device.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/uiautomator2/device.go
+++ b/pkg/uiautomator2/device.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/uiautomator2/device.go
+++ b/pkg/uiautomator2/device.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package uiautomator2
 
 import (

--- a/pkg/uiautomator2/device.go
+++ b/pkg/uiautomator2/device.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/uiautomator2/device_test.go
+++ b/pkg/uiautomator2/device_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/uiautomator2/device_test.go
+++ b/pkg/uiautomator2/device_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/uiautomator2/device_test.go
+++ b/pkg/uiautomator2/device_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package uiautomator2
 
 import (

--- a/pkg/uiautomator2/device_test.go
+++ b/pkg/uiautomator2/device_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/uiautomator2/element.go
+++ b/pkg/uiautomator2/element.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/uiautomator2/element.go
+++ b/pkg/uiautomator2/element.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/uiautomator2/element.go
+++ b/pkg/uiautomator2/element.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package uiautomator2
 
 import (

--- a/pkg/uiautomator2/element.go
+++ b/pkg/uiautomator2/element.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/uiautomator2/element_test.go
+++ b/pkg/uiautomator2/element_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/uiautomator2/element_test.go
+++ b/pkg/uiautomator2/element_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/uiautomator2/element_test.go
+++ b/pkg/uiautomator2/element_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package uiautomator2
 
 import (

--- a/pkg/uiautomator2/element_test.go
+++ b/pkg/uiautomator2/element_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/uiautomator2/gestures.go
+++ b/pkg/uiautomator2/gestures.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/uiautomator2/gestures.go
+++ b/pkg/uiautomator2/gestures.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package uiautomator2
 
 // Click performs a tap at coordinates or on an element.

--- a/pkg/uiautomator2/gestures.go
+++ b/pkg/uiautomator2/gestures.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/uiautomator2/gestures.go
+++ b/pkg/uiautomator2/gestures.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/uiautomator2/gestures_test.go
+++ b/pkg/uiautomator2/gestures_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/uiautomator2/gestures_test.go
+++ b/pkg/uiautomator2/gestures_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/uiautomator2/gestures_test.go
+++ b/pkg/uiautomator2/gestures_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package uiautomator2
 
 import (

--- a/pkg/uiautomator2/gestures_test.go
+++ b/pkg/uiautomator2/gestures_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/uiautomator2/testing.go
+++ b/pkg/uiautomator2/testing.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/uiautomator2/testing.go
+++ b/pkg/uiautomator2/testing.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package uiautomator2
 
 // NewTestElement creates an Element for testing purposes.

--- a/pkg/uiautomator2/testing.go
+++ b/pkg/uiautomator2/testing.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/uiautomator2/testing.go
+++ b/pkg/uiautomator2/testing.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/uiautomator2/types.go
+++ b/pkg/uiautomator2/types.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/uiautomator2/types.go
+++ b/pkg/uiautomator2/types.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/uiautomator2/types.go
+++ b/pkg/uiautomator2/types.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/uiautomator2/types.go
+++ b/pkg/uiautomator2/types.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 // Package uiautomator2 provides HTTP client for UIAutomator2 server.
 package uiautomator2
 

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 // Package validator validates Maestro flow files before execution.
 // It parses all files upfront, resolves runFlow references, and detects errors.
 package validator

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 DeviceLab
+//
+// SPDX-License-Identifier: LicenseRef-maestro-runner
+
 package validator
 
 import (

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab
+// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024–2026 DeviceLab and the Project Contributors
+// SPDX-FileCopyrightText: 2025 DeviceLab and the Project Contributors
 //
 // SPDX-License-Identifier: LicenseRef-maestro-runner
 


### PR DESCRIPTION
## Summary

This PR closes #105 by resolving all problems identified in that issue.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [x] Refactoring (no functional changes)

## Changes Made

- Added `SPDX-FileCopyrightText` and `SPDX-License-Identifier` headers to all ~230 source files
- Created `LICENSES/` directory with the required licenses and `REUSE.toml` for binary/untaggable assets
- Added `CONTRIBUTORS.md` and updated copyright headers to attribute project contributors
- Updated copyright year range to `2024–2026` across all files
- Added CI step (`.github/workflows`) to run `reuse lint` on every pull request
- Added REUSE compliance instructions to project documentation

## Related Issues

Fixes #105

## Testing

- [ ] Tests pass locally (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Added tests for new functionality
- [x] Tested manually with sample flows

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added/updated documentation as needed
- [x] No breaking changes (or documented if breaking)
- [ ] CHANGELOG.md updated (for notable changes)

## Additional Notes

All changes are purely metadata/header additions. No production logic was modified. 

Running `reuse lint` after this PR returns **781/784 files compliant**:

<details><summary>Full logs</summary>
<p>

# MISSING COPYRIGHT AND LICENSING INFORMATION

The following files have no copyright and licensing information:
* drivers/android/devicelab-android-driver-test.apk
* drivers/android/devicelab-android-driver.apk
* drivers/android/settings_apk-debug.apk

# SUMMARY

* Bad licenses: 0
* Deprecated licenses: 0
* Licenses without file extension: 0
* Missing licenses: 0
* Unused licenses: 0
* Used licenses: LicenseRef-CocoaHTTPServer, LicenseRef-RoutingHTTPServer, LicenseRef-agent-device, LicenseRef-appium-WebDriverAgent, LicenseRef-appium-uiautomator2-server, LicenseRef-maestro-runner
* Read errors: 0
* Invalid SPDX License Expressions: 0
* Files with copyright information: 781 / 784
* Files with license information: 781 / 784

Unfortunately, your project is not compliant with version 3.3 of the REUSE Specification :-(


# RECOMMENDATIONS

* Fix missing copyright/licensing information: For one or more files, the tool
  cannot find copyright and/or licensing information. You typically do this by
  adding 'SPDX-FileCopyrightText' and 'SPDX-License-Identifier' tags to each
  file. The tutorial explains additional ways to do this:
  <https://reuse.software/tutorial/>

</p>
</details> 

The project is not yet fully passing due to 3 first-party Android APKs whose exact licensing provenance is currently unknown:

- `drivers/android/devicelab-android-driver.apk`
- `drivers/android/devicelab-android-driver-test.apk`
- `drivers/android/settings_apk-debug.apk`

These are commented out in `REUSE.toml` pending clarification of their copyright owner and license. Once determined, they can be uncommented and annotated to bring the project to full REUSE compliance.

> [!NOTE]
> Please review the license and copyright annotations introduced by this PR carefully before merging. While reasonable efforts were made to determine the correct licensing information from upstream sources and file contents, maintainers should independently verify that the assigned licenses and copyright attributions are accurate and appropriate for this project.
