### PR TITLE
fix(uiautomator2): honour `swipe: from: <selector> direction:` on Android

### DIFF
--- a/pkg/driver/uiautomator2/commands.go
+++ b/pkg/driver/uiautomator2/commands.go
@@ -599,25 +599,21 @@ func (d *Driver) swipe(step *flow.SwipeStep) *core.CommandResult {
 		direction = "up"
 	}
 
-	uiaDir := mapDirection(direction)
-
-	// If selector specified, swipe within that element's bounds
+	// If selector specified, derive swipe coordinates from the element's
+	// bounds and route through the same ADB `input swipe` path used by
+	// screen-percentage swipes. `SwipeInArea` (the previous path) does not
+	// honor `step.Duration`, producing a fast flick — sufficient for scroll
+	// containers but too fast for native drag targets (Compose sliders,
+	// custom drag-handlers), which discard the gesture. Using the ADB path
+	// with an element-derived start/end matches classic Maestro's semantics.
 	if step.Selector != nil && !step.Selector.IsEmpty() {
 		_, info, err := d.findElement(*step.Selector, step.IsOptional(), step.TimeoutMs)
 		if err != nil {
 			return errorResult(err, fmt.Sprintf("Element not found for swipe: %v", err))
 		}
 		if info != nil && info.Bounds.Width > 0 {
-			area := uiautomator2.NewRect(
-				info.Bounds.X,
-				info.Bounds.Y,
-				info.Bounds.Width,
-				info.Bounds.Height,
-			)
-			if err := d.client.SwipeInArea(area, uiaDir, 0.7, 0); err != nil {
-				return errorResult(err, fmt.Sprintf("Failed to swipe in element: %v", err))
-			}
-			return successResult(fmt.Sprintf("Swiped %s in element", direction), info)
+			startX, startY, endX, endY := swipeCoordsInBounds(direction, info.Bounds)
+			return d.swipeWithAbsoluteCoords(startX, startY, endX, endY, step.Duration)
 		}
 	}
 
@@ -627,6 +623,43 @@ func (d *Driver) swipe(step *flow.SwipeStep) *core.CommandResult {
 		return errorResult(err, "Failed to get screen size")
 	}
 	return d.swipeWithMaestroCoordinates(direction, width, height, step.Duration)
+}
+
+// swipeCoordsInBounds returns absolute start/end coordinates for a
+// direction-based swipe anchored on an element. The swipe starts inside
+// the element (so the touch is captured by that element) and ends past
+// the opposite edge (so drag-based targets like native sliders reach
+// their extreme value). This matches classic Maestro's semantics on the
+// two common use cases:
+//   - scroll containers: touch starts inside and moves outward, scrolling
+//     the container by the drag distance
+//   - drag targets (sliders, drag handles): the release position past
+//     the edge pins the drag target to its extreme in that direction
+//
+// Negative coordinates are clamped to 0 (screen origin) so `adb input
+// swipe` receives on-screen coordinates even for elements flush against
+// a screen edge.
+func swipeCoordsInBounds(direction string, b core.Bounds) (startX, startY, endX, endY int) {
+	clamp := func(v int) int {
+		if v < 0 {
+			return 0
+		}
+		return v
+	}
+	pctX := func(p int) int { return clamp(b.X + b.Width*p/100) }
+	pctY := func(p int) int { return clamp(b.Y + b.Height*p/100) }
+	switch direction {
+	case "up":
+		return pctX(50), pctY(90), pctX(50), pctY(-10)
+	case "down":
+		return pctX(50), pctY(10), pctX(50), pctY(110)
+	case "left":
+		return pctX(90), pctY(50), pctX(-10), pctY(50)
+	case "right":
+		return pctX(10), pctY(50), pctX(110), pctY(50)
+	default:
+		return pctX(50), pctY(50), pctX(50), pctY(0)
+	}
 }
 
 // findScrollableElement waits for and finds a scrollable element.

--- a/pkg/driver/uiautomator2/commands_test.go
+++ b/pkg/driver/uiautomator2/commands_test.go
@@ -3424,24 +3424,31 @@ func TestSwipeWithSelectorDirection(t *testing.T) {
 				"value": map[string]int{"x": 0, "y": 100, "width": 500, "height": 800},
 			})
 		},
-		"POST /appium/gestures/swipe": func(w http.ResponseWriter, r *http.Request) {
-			writeJSON(w, map[string]interface{}{"value": nil})
-		},
 	})
 	defer server.Close()
 
 	client := newMockHTTPClient(server.URL)
-	driver := New(client.Client, nil, nil)
+	// Selector-anchored direction swipes now route through `adb input swipe`
+	// (see swipe() in commands.go), so the driver needs a shell executor.
+	shell := &MockShellExecutor{}
+	driver := New(client.Client, nil, shell)
 
 	sel := flow.Selector{ID: "container"}
-	step := &flow.SwipeStep{Direction: "left", Selector: &sel}
+	step := &flow.SwipeStep{Direction: "left", Selector: &sel, Duration: 500}
 	result := driver.swipe(step)
 
 	if !result.Success {
 		t.Errorf("expected success, got error: %v", result.Error)
 	}
-	if !strings.Contains(result.Message, "left") {
-		t.Errorf("expected 'left' in message, got: %s", result.Message)
+	// Element bounds: x=0, y=100, w=500, h=800. `left` starts inside the
+	// element (90% X) and ends 10% past its left edge — for x=0 the end
+	// clamps to 0. Y is 50% within the bounds → (450, 500) → (0, 500).
+	if len(shell.commands) != 1 {
+		t.Fatalf("expected exactly 1 shell command, got %d: %v", len(shell.commands), shell.commands)
+	}
+	want := "input swipe 450 500 0 500 500"
+	if !strings.Contains(shell.commands[0], want) {
+		t.Errorf("expected shell command containing %q, got: %s", want, shell.commands[0])
 	}
 }
 

--- a/pkg/flow/parser_test.go
+++ b/pkg/flow/parser_test.go
@@ -946,6 +946,71 @@ func TestParse_SwipeWithAllFields(t *testing.T) {
 	}
 }
 
+// See devicelab-dev/maestro-runner#112 — `from: {id: X}` used to be silently
+// discarded, causing direction-swipes to ignore the anchor and fall through
+// to a screen-percentage swipe.
+func TestParse_SwipeFromKeyPopulatesSelector(t *testing.T) {
+	yaml := `
+- swipe:
+    from:
+      id: 'SliderTestID'
+    direction: LEFT
+    duration: 1500
+`
+	flow, err := Parse([]byte(yaml), "test.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	swipe := flow.Steps[0].(*SwipeStep)
+	if swipe.Selector == nil {
+		t.Fatal("Selector is nil — `from:` was not parsed")
+	}
+	if swipe.Selector.ID != "SliderTestID" {
+		t.Errorf("Selector.ID=%q, want SliderTestID", swipe.Selector.ID)
+	}
+	if swipe.Direction != "LEFT" {
+		t.Errorf("Direction=%q, want LEFT", swipe.Direction)
+	}
+}
+
+// Historical `selector:` key remains supported for backward compatibility.
+func TestParse_SwipeSelectorKeyStillWorks(t *testing.T) {
+	yaml := `
+- swipe:
+    selector:
+      id: 'MyListView'
+    direction: DOWN
+`
+	flow, err := Parse([]byte(yaml), "test.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	swipe := flow.Steps[0].(*SwipeStep)
+	if swipe.Selector == nil || swipe.Selector.ID != "MyListView" {
+		t.Fatalf("expected Selector.ID=MyListView, got %+v", swipe.Selector)
+	}
+}
+
+// `from:` wins if both keys are present.
+func TestParse_SwipeFromPrecedenceOverSelector(t *testing.T) {
+	yaml := `
+- swipe:
+    from:
+      id: 'PrimaryAnchor'
+    selector:
+      id: 'FallbackAnchor'
+    direction: LEFT
+`
+	flow, err := Parse([]byte(yaml), "test.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	swipe := flow.Steps[0].(*SwipeStep)
+	if swipe.Selector == nil || swipe.Selector.ID != "PrimaryAnchor" {
+		t.Fatalf("expected Selector.ID=PrimaryAnchor (from), got %+v", swipe.Selector)
+	}
+}
+
 func TestParse_ScrollUntilVisibleWithAllFields(t *testing.T) {
 	yaml := `
 - scrollUntilVisible:

--- a/pkg/flow/step.go
+++ b/pkg/flow/step.go
@@ -191,10 +191,15 @@ type TapOnPointStep struct {
 }
 
 // SwipeStep performs a swipe gesture.
+//
+// `Selector` anchors the swipe on an element. It is populated from either the
+// `from:` YAML key (matching upstream Maestro syntax) or the historical
+// `selector:` key. Custom `UnmarshalYAML` handles the mapping — both keys
+// resolve to the same field, with `from:` taking precedence if both are set.
 type SwipeStep struct {
 	BaseStep              `yaml:",inline"`
 	Direction             string    `yaml:"direction"` // UP, DOWN, LEFT, RIGHT
-	Selector              *Selector `yaml:"selector"`
+	Selector              *Selector `yaml:"-"`
 	Start                 string    `yaml:"start"`    // "x%, y%"
 	End                   string    `yaml:"end"`      // "x%, y%"
 	StartX                int       `yaml:"startX"`   // Absolute X start
@@ -204,6 +209,34 @@ type SwipeStep struct {
 	Duration              int       `yaml:"duration"` // Duration in ms
 	Speed                 int       `yaml:"speed"`    // Speed 0-100
 	WaitToSettleTimeoutMs int       `yaml:"waitToSettleTimeoutMs"`
+}
+
+// UnmarshalYAML decodes SwipeStep and maps both `from:` (upstream Maestro
+// spelling) and `selector:` (historical) to the `Selector` field. Without
+// this, `from: {id: X}` was silently discarded and direction-swipes fell
+// through to a screen-percentage swipe that ignores the anchor element.
+// See devicelab-dev/maestro-runner#112.
+func (s *SwipeStep) UnmarshalYAML(node *yaml.Node) error {
+	type swipeAlias SwipeStep
+	var a swipeAlias
+	if err := node.Decode(&a); err != nil {
+		return err
+	}
+	*s = SwipeStep(a)
+
+	var anchor struct {
+		From     *Selector `yaml:"from"`
+		Selector *Selector `yaml:"selector"`
+	}
+	if err := node.Decode(&anchor); err != nil {
+		return err
+	}
+	if anchor.From != nil {
+		s.Selector = anchor.From
+	} else if anchor.Selector != nil {
+		s.Selector = anchor.Selector
+	}
+	return nil
 }
 
 // ScrollStep scrolls the screen.


### PR DESCRIPTION
Fixes #114.

## What was broken

Two independent bugs prevented `swipe: from: <selector> direction: <dir>` from working on Android:

1. **Parser dropped `from:`** — `SwipeStep.Selector` was tagged `yaml:"selector"`, so the standard Maestro `from:` key was silently discarded and the swipe fell through to the screen-percentage code path (`swipeWithMaestroCoordinates`), swiping at `screen_height / 2` regardless of where the anchor element was.

2. **Element-anchored path used a fast-flick backend** — `SwipeInArea` calls the UIA2 gesture endpoint with a hard-coded speed and no `duration:` plumbing. Sufficient for scroll containers, but native drag targets (Compose sliders, custom drag-handlers) discard the gesture and the release position doesn't stick.

## Fix (two commits)

**`fix(flow): parse 'swipe: from:' into Selector`** — adds `UnmarshalYAML` on `SwipeStep` that accepts either `from:` (upstream Maestro spelling — takes precedence) or the historical `selector:` key. Both feed the same `Selector` field. Existing YAML that used `selector:` keeps working; YAML that used `from:` now behaves as documented.

**`fix(uiautomator2): route selector-anchored swipes through adb input swipe`** — reroutes the element-anchored path to `swipeWithAbsoluteCoords` (the same ADB backend used by screen-percentage swipes). Coordinates are derived from the element's bounds: start inside the element (so touch is captured), end 10% past the opposite edge (so drag targets reach their extreme in the requested direction). Negative results clamp to 0 for elements flush against a screen edge. `duration:` is honoured end-to-end.

## Tests

`pkg/flow/parser_test.go` — three new parser tests:
- `TestParse_SwipeFromKeyPopulatesSelector` — `from: {id: X}` populates Selector
- `TestParse_SwipeSelectorKeyStillWorks` — historical `selector: {id: X}` still works
- `TestParse_SwipeFromPrecedenceOverSelector` — `from:` wins when both are present

`pkg/driver/uiautomator2/commands_test.go` — `TestSwipeWithSelectorDirection` updated to a shell-backed mock and asserts the exact ADB command for a `LEFT` swipe on a 500x800 element at x=0, y=100: `input swipe 450 500 0 500 500`.

`go test ./pkg/flow/... ./pkg/driver/uiautomator2/...` passes locally.

## End-to-end verification

Built the binary from this branch and ran a flow of the form:

```yaml
- swipe:
    from:
      id: 'AnchorView'
    direction: LEFT
    duration: 1500
```

against a Compose slider on Android. Before: slider didn't move. After: single swipe drags the thumb to the minimum value. Runner no longer prints `[swipe] Using screen coords: ...` — the swipe is routed via the element-derived ADB path.