### PR TITLE
fix(wda): preserve deep React Native hierarchies

### DIFF
--- a/pkg/driver/wda/commands.go
+++ b/pkg/driver/wda/commands.go
@@ -820,6 +820,7 @@ func (d *Driver) launchApp(step *flow.LaunchAppStep) *core.CommandResult {
 	// reusing a session from a previous flow with different permissions.
 	sessionSettings := map[string]interface{}{
 		"shouldWaitForQuiescence": false,
+		"snapshotMaxDepth":        60,
 		"waitForIdleTimeout":      0,
 		"defaultAlertAction":      d.alertAction,
 	}

--- a/pkg/driver/wda/commands_test.go
+++ b/pkg/driver/wda/commands_test.go
@@ -4685,6 +4685,7 @@ func TestStopAppEmptyBundleID(t *testing.T) {
 func TestEnsureSessionCreatesSessionWhenNone(t *testing.T) {
 	var sessionCreated bool
 	var settingsUpdated bool
+	var settingsBody string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		path := r.URL.Path
@@ -4698,6 +4699,8 @@ func TestEnsureSessionCreatesSessionWhenNone(t *testing.T) {
 		}
 		if strings.Contains(path, "/appium/settings") && r.Method == "POST" {
 			settingsUpdated = true
+			body, _ := io.ReadAll(r.Body)
+			settingsBody = string(body)
 			jsonResponse(w, map[string]interface{}{"status": 0})
 			return
 		}
@@ -4718,6 +4721,9 @@ func TestEnsureSessionCreatesSessionWhenNone(t *testing.T) {
 	}
 	if !settingsUpdated {
 		t.Error("Expected settings to be updated after session creation")
+	}
+	if !strings.Contains(settingsBody, `"snapshotMaxDepth":60`) {
+		t.Errorf("Expected snapshotMaxDepth=60, got %s", settingsBody)
 	}
 }
 
@@ -4750,6 +4756,7 @@ func TestEnsureSessionSkipsWhenSessionExists(t *testing.T) {
 func TestLaunchAppReusesExistingSession(t *testing.T) {
 	var sessionCreated bool
 	var settingsUpdated bool
+	var settingsBody string
 	var launchCalled bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -4764,6 +4771,8 @@ func TestLaunchAppReusesExistingSession(t *testing.T) {
 		}
 		if strings.Contains(path, "/appium/settings") && r.Method == "POST" {
 			settingsUpdated = true
+			body, _ := io.ReadAll(r.Body)
+			settingsBody = string(body)
 			jsonResponse(w, map[string]interface{}{"status": 0})
 			return
 		}
@@ -4794,6 +4803,9 @@ func TestLaunchAppReusesExistingSession(t *testing.T) {
 	}
 	if !settingsUpdated {
 		t.Error("Expected UpdateSettings to be called for existing session")
+	}
+	if !strings.Contains(settingsBody, `"snapshotMaxDepth":60`) {
+		t.Errorf("Expected snapshotMaxDepth=60, got %s", settingsBody)
 	}
 	if !launchCalled {
 		t.Error("Expected app launch to be called")

--- a/pkg/driver/wda/driver.go
+++ b/pkg/driver/wda/driver.go
@@ -124,6 +124,7 @@ func (d *Driver) EnsureSession(appID string) error {
 	// Disable quiescence to prevent XCTest crashes
 	_ = d.client.UpdateSettings(map[string]interface{}{
 		"shouldWaitForQuiescence": false,
+		"snapshotMaxDepth":        60,
 		"waitForIdleTimeout":      0,
 	})
 	return nil


### PR DESCRIPTION
## Summary

- raise WDA `snapshotMaxDepth` from its default 50 to 60 for iOS sessions
- apply the setting both during implicit session setup and `launchApp`
- cover both session paths with regression assertions

## Why

React Native 0.86 on iOS 26.5 produced a visible `TextInput` at hierarchy depth 53. WDA truncated the source at depth 50, so `assertVisible` could not match its `testID` even though it was on screen. Setting the depth to 60 exposed the element and allowed the sign-in flow to proceed. This also matches Maestro's iOS XCTest runner depth.

Related React Native report: https://github.com/facebook/react-native/issues/57282
Maestro hierarchy workaround: https://github.com/mobile-dev-inc/Maestro/pull/1209

## Verification

- `go test ./pkg/driver/wda -count=1`
- `go vet ./...`
- reproduced failure with stock 1.1.19; patched binary passed the hierarchy probe and advanced the real flow through sign-in

`go test ./...` also ran; only the existing environment-sensitive AVD tests failed because local Android emulators were present (`TestListAvailableAVDs_NoEmulatorBinary`, `TestListAVDs_NoEmulatorBinary`).