### PR TITLE
fix(web): expand flow header variables before browser launch

### DIFF
--- a/pkg/cli/web.go
+++ b/pkg/cli/web.go
@@ -5,22 +5,18 @@ import (
 
 	"github.com/devicelab-dev/maestro-runner/pkg/core"
 	cdpdriver "github.com/devicelab-dev/maestro-runner/pkg/driver/browser/cdp"
+	"github.com/devicelab-dev/maestro-runner/pkg/executor"
 	"github.com/devicelab-dev/maestro-runner/pkg/logger"
 )
 
 // CreateWebDriver creates a browser driver using Rod + CDP.
 // Exported for library use.
 func CreateWebDriver(cfg *RunConfig) (core.Driver, func(), error) {
-	headless := !cfg.Headed
+	driverConfig := buildWebDriverConfig(cfg)
 	printSetupStep("Launching browser...")
-	logger.Info("Creating web driver (headless=%v)", headless)
+	logger.Info("Creating web driver (headless=%v)", driverConfig.Headless)
 
-	driver, err := cdpdriver.New(cdpdriver.Config{
-		Headless:    headless,
-		URL:         cfg.AppID,
-		Browser:     cfg.Browser,
-		UserDataDir: cfg.UserDataDir,
-	})
+	driver, err := cdpdriver.New(driverConfig)
 	if err != nil {
 		logger.Error("Failed to launch browser: %v", err)
 		return nil, nil, fmt.Errorf("launch browser: %w", err)
@@ -33,4 +29,20 @@ func CreateWebDriver(cfg *RunConfig) (core.Driver, func(), error) {
 		}
 	}
 	return driver, cleanup, nil
+}
+
+// buildWebDriverConfig expands the flow header with the runner environment
+// before the CDP driver's initial navigation.
+func buildWebDriverConfig(cfg *RunConfig) cdpdriver.Config {
+	script := executor.NewScriptEngine()
+	defer script.Close()
+	script.ImportSystemEnv()
+	script.SetVariables(cfg.Env)
+
+	return cdpdriver.Config{
+		Headless:    !cfg.Headed,
+		URL:         script.ExpandVariables(cfg.AppID),
+		Browser:     cfg.Browser,
+		UserDataDir: cfg.UserDataDir,
+	}
 }

--- a/pkg/cli/web_test.go
+++ b/pkg/cli/web_test.go
@@ -1,0 +1,29 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/devicelab-dev/maestro-runner/pkg/flow"
+)
+
+func TestBuildWebDriverConfig_ExpandsFlowHeaderBeforeNavigate(t *testing.T) {
+	const appURL = "http://127.0.0.1:3000"
+
+	parsed, err := flow.Parse(
+		[]byte("url: ${BASE_URL}\n---\n- launchApp\n"),
+		"flow.yaml",
+	)
+	if err != nil {
+		t.Fatalf("parse flow: %v", err)
+	}
+
+	cfg := &RunConfig{
+		AppID: parsed.Config.EffectiveAppID(),
+		Env:   map[string]string{"BASE_URL": appURL},
+	}
+
+	got := buildWebDriverConfig(cfg)
+	if got.URL != appURL {
+		t.Fatalf("browser navigate URL = %q, want %q", got.URL, appURL)
+	}
+}


### PR DESCRIPTION
## Summary

Expand the Web flow header `url` / `appId` with the existing `ScriptEngine` before creating the CDP driver.

This allows variables supplied through `-e`, `--env-file`, and workspace configuration to be used during the initial browser navigation.

## Tests

- Added a regression test for `url: ${BASE_URL}`
- Passed `pkg/cli` tests
- Passed race tests across all packages
- Verified the fix with Chrome

Closes #145
