### PR TITLE
fix(appium): match Android checked state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   maestro-runner --driver appium --caps caps.json --new-command-timeout 300 --parallel 4 test flows/
   ```
 
+### Fixed
+- **Appium Android `checked:` selectors used the unrelated `selected` state** — the page-source parser now retains the XML `checked` attribute and state filtering reads it directly, so checked and unchecked switches match correctly even when `selected` differs ([#153](https://github.com/devicelab-dev/maestro-runner/issues/153)).
+
 ## [1.1.25] - 2026-08-25
 
 This release is about **the first five minutes and the oldest complaints**: a `doctor` that says exactly what your machine is missing, a `devices` listing, a `screenshot` command, `runShell` for the one adb call every suite eventually needs, and an `inputText` that checks what actually landed in the field. It is also about **gestures that behave like a user's finger**: a real `dragAndDrop` on every driver — press, hold until the item lifts, move slowly, settle, release — and a `scrollUntilVisible` that stops when the element is actually visible instead of one pixel in. Flutter apps go from barely drivable to ahead of WDA on the DeviceLab iOS driver, `--step-delay` slows any flow down for demos and animation-heavy apps, and JUnit reports carry test-tracking properties and failure artifacts into CI.

--- a/pkg/driver/appium/pagesource.go
+++ b/pkg/driver/appium/pagesource.go
@@ -19,6 +19,7 @@ type ParsedElement struct {
 	Enabled   bool
 	Displayed bool
 	Selected  bool
+	Checked   bool
 	Focused   bool
 	Clickable bool
 	Depth     int
@@ -99,6 +100,8 @@ func parseAndroidPageSource(xmlData string) ([]*ParsedElement, error) {
 						elem.Enabled = attr.Value == "true"
 					case "selected":
 						elem.Selected = attr.Value == "true"
+					case "checked":
+						elem.Checked = attr.Value == "true"
 					case "focused":
 						elem.Focused = attr.Value == "true"
 					case "displayed":
@@ -365,7 +368,7 @@ func matchesSelector(elem *ParsedElement, sel flow.Selector, platform string) bo
 	if sel.Focused != nil && elem.Focused != *sel.Focused {
 		return false
 	}
-	if sel.Checked != nil && elem.Selected != *sel.Checked {
+	if sel.Checked != nil && elem.Checked != *sel.Checked {
 		return false
 	}
 

--- a/pkg/driver/appium/pagesource_test.go
+++ b/pkg/driver/appium/pagesource_test.go
@@ -76,6 +76,40 @@ func TestParseAndroidPageSource(t *testing.T) {
 	}
 }
 
+func TestFilterBySelector_AndroidCheckedState(t *testing.T) {
+	xml := `<?xml version="1.0" encoding="UTF-8"?>
+<hierarchy rotation="0">
+  <android.widget.Switch resource-id="notifications" checkable="true" checked="true" selected="false" enabled="true" displayed="true" bounds="[0,0][100,50]" />
+  <android.widget.Switch resource-id="marketing" checkable="true" checked="false" selected="true" enabled="true" displayed="true" bounds="[0,50][100,100]" />
+</hierarchy>`
+
+	elements, platform, err := ParsePageSource(xml)
+	if err != nil {
+		t.Fatalf("ParsePageSource failed: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		checked    bool
+		resourceID string
+	}{
+		{name: "checked", checked: true, resourceID: "notifications"},
+		{name: "unchecked", checked: false, resourceID: "marketing"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FilterBySelector(elements, flow.Selector{Checked: &tt.checked}, platform)
+			if len(result) != 1 {
+				t.Fatalf("Expected 1 %s element, got %d", tt.name, len(result))
+			}
+			if result[0].ResourceID != tt.resourceID {
+				t.Errorf("Expected %s switch %q, got %q", tt.name, tt.resourceID, result[0].ResourceID)
+			}
+		})
+	}
+}
+
 func TestParseIOSPageSource(t *testing.T) {
 	xml := `<?xml version="1.0" encoding="UTF-8"?>
 <AppiumAUT>


### PR DESCRIPTION
## Summary

Fix Android Appium `checked:` selectors so they read the hierarchy `checked` attribute instead of the unrelated `selected` state.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change or feature that changes existing behavior
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

- Retain Android XML `checked` state in `ParsedElement`.
- Compare `Selector.Checked` with the parsed checked state.
- Add a regression fixture where checked and selected deliberately disagree in both directions.
- Document the fix under Unreleased.

## Related Issues

Fixes #153

## Testing

- [ ] Full `make test` passes locally
- [ ] Full linting passes
- [x] Added tests for new functionality
- [x] Tested manually with sample flows

Passed locally:

- `go test ./pkg/driver/appium -count=1`
- `go test -race ./pkg/driver/appium -count=1`
- `go vet ./pkg/driver/appium`
- `go build .`
- Original Sauce Labs reproduction with `checked: true` before the tap and `checked: false` after it: 80/80 steps passed on Pixel 8 / Android 14 — https://app.saucelabs.com/tests/e95b01337f2145fd8c02d14c5cd0990f

The repository-wide `go test ./...` run encountered an unrelated environment-sensitive failure in `TestListAvailableAVDs_NoEmulatorBinary` because this workstation has Android AVDs installed, then was bounded while the browser/CDP package ran its first-time Chromium tests. The complete changed Appium package passes, including under the race detector.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added/updated documentation as needed
- [x] No breaking changes
- [x] CHANGELOG.md updated

## Additional Notes

The production change is two behaviors: parse `checked`, then filter against it. The regression exercises the same XML shape observed through Appium on Sauce Labs (`checked=true`, `selected=false`).