### PR TITLE
fix(android): require id and text on the same element in both drivers

### DIFF
--- a/pkg/driver/devicelab/driver.go
+++ b/pkg/driver/devicelab/driver.go
@@ -1736,126 +1736,97 @@ func buildSelectorsWithOptions(sel flow.Selector, timeoutMs int, preferClickable
 	var strategies []LocatorStrategy
 	stateFilters := buildStateFilters(sel)
 
-	// ID-based selector — exact match FIRST, substring fallback ONLY if exact
-	// fails. Mirrors the parallel fix in pkg/driver/uiautomator2: substring-
-	// only `resourceIdMatches(".*X.*")` triggered internal scrolling and
-	// returned a wrong element when the target id wasn't in the rendered
-	// tree (lazy ListView with target offscreen). Web driver does the same
-	// cascade — exact → testid → substring → name → aria-label.
-	if sel.ID != "" {
-		escaped := escapeUIAutomatorString(sel.ID)
-		if preferClickable {
-			// Exact match — clickable first for tap commands.
-			strategies = append(strategies, LocatorStrategy{
-				Strategy: uiautomator2.StrategyUIAutomator,
-				Value:    `new UiSelector().resourceId("` + escaped + `").clickable(true)` + stateFilters,
-			})
+	// One tier is a set of equally-good queries; tiers are tried in order, and
+	// within a tier the clickable variants come first when a tap is being
+	// located.
+	emit := func(tiers [][]string) {
+		for _, tier := range tiers {
+			if preferClickable {
+				for _, body := range tier {
+					strategies = append(strategies, LocatorStrategy{
+						Strategy: uiautomator2.StrategyUIAutomator,
+						Value:    `new UiSelector()` + body + `.clickable(true)` + stateFilters,
+					})
+				}
+			}
+			for _, body := range tier {
+				strategies = append(strategies, LocatorStrategy{
+					Strategy: uiautomator2.StrategyUIAutomator,
+					Value:    `new UiSelector()` + body + stateFilters,
+				})
+			}
 		}
-		// Exact match — any element.
-		strategies = append(strategies, LocatorStrategy{
-			Strategy: uiautomator2.StrategyUIAutomator,
-			Value:    `new UiSelector().resourceId("` + escaped + `")` + stateFilters,
-		})
-		if preferClickable {
-			// Substring fallback — clickable. Backward compat with users
-			// relying on substring behaviour.
-			strategies = append(strategies, LocatorStrategy{
-				Strategy: uiautomator2.StrategyUIAutomator,
-				Value:    `new UiSelector().resourceIdMatches(".*` + escaped + `.*").clickable(true)` + stateFilters,
-			})
-		}
-		// Substring fallback — any.
-		strategies = append(strategies, LocatorStrategy{
-			Strategy: uiautomator2.StrategyUIAutomator,
-			Value:    `new UiSelector().resourceIdMatches(".*` + escaped + `.*")` + stateFilters,
-		})
 	}
 
-	// Text-based selector: case-sensitive first, case-insensitive fallback.
-	// hintContains / hintMatches are DeviceLab-agent extensions — match EditText
-	// android:hint placeholder so "tapOn: 'Email'" finds an empty field by hint.
+	// ID — exact match FIRST, substring fallback ONLY if exact fails. Mirrors
+	// the parallel fix in pkg/driver/uiautomator2: substring-only
+	// `resourceIdMatches(".*X.*")` triggered internal scrolling and returned a
+	// wrong element when the target id wasn't in the rendered tree (lazy
+	// ListView with target offscreen).
+	var idTiers [][]string
+	if sel.ID != "" {
+		escaped := escapeUIAutomatorString(sel.ID)
+		idTiers = [][]string{
+			{`.resourceId("` + escaped + `")`},
+			{`.resourceIdMatches(".*` + escaped + `.*")`},
+		}
+	}
+
+	// Text — case-sensitive first, case-insensitive fallback. hintContains /
+	// hintMatches are DeviceLab-agent extensions: they match the EditText
+	// android:hint placeholder, so "tapOn: 'Email'" finds an empty field by
+	// hint.
+	var textTiers [][]string
 	if sel.Text != "" {
 		escaped := escapeUIAutomatorString(sel.Text)
 		ciPattern := `(?is).*\Q` + escaped + `\E.*`
-		if preferClickable {
-			strategies = append(strategies, LocatorStrategy{
-				Strategy: uiautomator2.StrategyUIAutomator,
-				Value:    `new UiSelector().textContains("` + escaped + `").clickable(true)` + stateFilters,
-			})
-			strategies = append(strategies, LocatorStrategy{
-				Strategy: uiautomator2.StrategyUIAutomator,
-				Value:    `new UiSelector().descriptionContains("` + escaped + `").clickable(true)` + stateFilters,
-			})
-			strategies = append(strategies, LocatorStrategy{
-				Strategy: uiautomator2.StrategyUIAutomator,
-				Value:    `new UiSelector().hintContains("` + escaped + `").clickable(true)` + stateFilters,
-			})
+		textTiers = [][]string{
+			{
+				`.textContains("` + escaped + `")`,
+				`.descriptionContains("` + escaped + `")`,
+				`.hintContains("` + escaped + `")`,
+			},
+			{
+				`.textMatches("` + ciPattern + `")`,
+				`.descriptionMatches("` + ciPattern + `")`,
+				`.hintMatches("` + ciPattern + `")`,
+			},
 		}
-		strategies = append(strategies, LocatorStrategy{
-			Strategy: uiautomator2.StrategyUIAutomator,
-			Value:    `new UiSelector().textContains("` + escaped + `")` + stateFilters,
-		})
-		strategies = append(strategies, LocatorStrategy{
-			Strategy: uiautomator2.StrategyUIAutomator,
-			Value:    `new UiSelector().descriptionContains("` + escaped + `")` + stateFilters,
-		})
-		strategies = append(strategies, LocatorStrategy{
-			Strategy: uiautomator2.StrategyUIAutomator,
-			Value:    `new UiSelector().hintContains("` + escaped + `")` + stateFilters,
-		})
-		// Case-insensitive fallback
-		if preferClickable {
-			strategies = append(strategies, LocatorStrategy{
-				Strategy: uiautomator2.StrategyUIAutomator,
-				Value:    `new UiSelector().textMatches("` + ciPattern + `").clickable(true)` + stateFilters,
-			})
-			strategies = append(strategies, LocatorStrategy{
-				Strategy: uiautomator2.StrategyUIAutomator,
-				Value:    `new UiSelector().descriptionMatches("` + ciPattern + `").clickable(true)` + stateFilters,
-			})
-			strategies = append(strategies, LocatorStrategy{
-				Strategy: uiautomator2.StrategyUIAutomator,
-				Value:    `new UiSelector().hintMatches("` + ciPattern + `").clickable(true)` + stateFilters,
-			})
-		}
-		strategies = append(strategies, LocatorStrategy{
-			Strategy: uiautomator2.StrategyUIAutomator,
-			Value:    `new UiSelector().textMatches("` + ciPattern + `")` + stateFilters,
-		})
-		strategies = append(strategies, LocatorStrategy{
-			Strategy: uiautomator2.StrategyUIAutomator,
-			Value:    `new UiSelector().descriptionMatches("` + ciPattern + `")` + stateFilters,
-		})
-		strategies = append(strategies, LocatorStrategy{
-			Strategy: uiautomator2.StrategyUIAutomator,
-			Value:    `new UiSelector().hintMatches("` + ciPattern + `")` + stateFilters,
-		})
-		// Fall back to regex match (case-insensitive). Text is already a regex
-		// per looksLikeRegex — use it as-is; only escape Java-string quotes.
-		// Escaping regex metachars here would defeat the regex (turns `.*` into
-		// `\.\*` which matches the literal string ".*").
+		// Text is already a regex per looksLikeRegex — use it as-is; only
+		// escape Java-string quotes. Escaping regex metachars here would defeat
+		// the regex (turns `.*` into `\.\*`, matching the literal ".*").
 		if looksLikeRegex(sel.Text) {
-			regexEscaped := escapeUIAutomatorString(sel.Text)
-			pattern := "(?is)" + regexEscaped
-			if preferClickable {
-				strategies = append(strategies, LocatorStrategy{
-					Strategy: uiautomator2.StrategyUIAutomator,
-					Value:    `new UiSelector().textMatches("` + pattern + `").clickable(true)` + stateFilters,
-				})
-				strategies = append(strategies, LocatorStrategy{
-					Strategy: uiautomator2.StrategyUIAutomator,
-					Value:    `new UiSelector().descriptionMatches("` + pattern + `").clickable(true)` + stateFilters,
-				})
-			}
-			strategies = append(strategies, LocatorStrategy{
-				Strategy: uiautomator2.StrategyUIAutomator,
-				Value:    `new UiSelector().textMatches("` + pattern + `")` + stateFilters,
-			})
-			strategies = append(strategies, LocatorStrategy{
-				Strategy: uiautomator2.StrategyUIAutomator,
-				Value:    `new UiSelector().descriptionMatches("` + pattern + `")` + stateFilters,
+			pattern := "(?is)" + escapeUIAutomatorString(sel.Text)
+			textTiers = append(textTiers, []string{
+				`.textMatches("` + pattern + `")`,
+				`.descriptionMatches("` + pattern + `")`,
 			})
 		}
+	}
+
+	// A selector naming both must match one element carrying both. Emitting the
+	// id-only and text-only queries as separate candidates made them an OR: the
+	// finder returns on the first that hits anything, so the id matched and the
+	// text was never read. Same defect as the WDA one fixed in #130.
+	switch {
+	case len(idTiers) > 0 && len(textTiers) > 0:
+		var combined [][]string
+		for _, idTier := range idTiers {
+			for _, textTier := range textTiers {
+				var tier []string
+				for _, id := range idTier {
+					for _, text := range textTier {
+						tier = append(tier, id+text)
+					}
+				}
+				combined = append(combined, tier)
+			}
+		}
+		emit(combined)
+	case len(idTiers) > 0:
+		emit(idTiers)
+	case len(textTiers) > 0:
+		emit(textTiers)
 	}
 
 	// CSS selector for web views

--- a/pkg/driver/devicelab/idtext_and_test.go
+++ b/pkg/driver/devicelab/idtext_and_test.go
@@ -1,0 +1,87 @@
+package devicelab
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/devicelab-dev/maestro-runner/pkg/flow"
+)
+
+// TestBuildSelectors_IDAndTextAreANDed is the correctness guarantee behind the
+// Android half of #130: a selector naming both an id and a text must match one
+// element carrying both.
+//
+// Before this, the builder emitted resourceId-only strategies and then
+// text-only ones as separate candidates, and tryFindElementFast returns on the
+// first that finds anything — so the id matched, the text was never read, and a
+// wrong text: passed green against the right element.
+func TestBuildSelectors_IDAndTextAreANDed(t *testing.T) {
+	strategies, err := buildSelectors(flow.Selector{ID: "boss.hp", Text: "7 misses"}, 5000)
+	if err != nil {
+		t.Fatalf("buildSelectors failed: %v", err)
+	}
+	if len(strategies) == 0 {
+		t.Fatal("expected at least one strategy")
+	}
+
+	for _, s := range strategies {
+		hasID := strings.Contains(s.Value, "resourceId")
+		hasText := strings.Contains(s.Value, "text") ||
+			strings.Contains(s.Value, "description") ||
+			strings.Contains(s.Value, "hint")
+		if !hasID || !hasText {
+			t.Errorf("every strategy must constrain both id and text, got: %s", s.Value)
+		}
+	}
+}
+
+// The single-attribute paths are unchanged: given only one of the two, the
+// builder still emits the queries it always did.
+func TestBuildSelectors_SingleAttributeUnchanged(t *testing.T) {
+	idOnly, err := buildSelectors(flow.Selector{ID: "boss.hp"}, 5000)
+	if err != nil {
+		t.Fatalf("buildSelectors failed: %v", err)
+	}
+	// Exact resourceId, then the substring fallback.
+	if len(idOnly) != 2 {
+		t.Errorf("expected 2 id strategies, got %d", len(idOnly))
+	}
+	for _, s := range idOnly {
+		if strings.Contains(s.Value, "textContains") || strings.Contains(s.Value, "textMatches") {
+			t.Errorf("id-only selector must not constrain text, got: %s", s.Value)
+		}
+	}
+
+	textOnly, err := buildSelectors(flow.Selector{Text: "7 misses"}, 5000)
+	if err != nil {
+		t.Fatalf("buildSelectors failed: %v", err)
+	}
+	// text/description/hint contains, then the same three case-insensitively.
+	if len(textOnly) != 6 {
+		t.Errorf("expected 6 text strategies, got %d", len(textOnly))
+	}
+	for _, s := range textOnly {
+		if strings.Contains(s.Value, "resourceId") {
+			t.Errorf("text-only selector must not constrain id, got: %s", s.Value)
+		}
+	}
+}
+
+// A tap prefers a clickable element, and that preference has to survive the
+// combination rather than being dropped along with the separate strategies.
+func TestBuildSelectorsForTap_CombinedKeepsClickableFirst(t *testing.T) {
+	strategies, err := buildSelectorsForTap(flow.Selector{ID: "boss.hp", Text: "7 misses"}, 5000)
+	if err != nil {
+		t.Fatalf("buildSelectorsForTap failed: %v", err)
+	}
+	if len(strategies) == 0 {
+		t.Fatal("expected at least one strategy")
+	}
+	if !strings.Contains(strategies[0].Value, "clickable(true)") {
+		t.Errorf("expected a clickable-first strategy, got: %s", strategies[0].Value)
+	}
+	if !strings.Contains(strategies[0].Value, "resourceId") ||
+		!strings.Contains(strategies[0].Value, "textContains") {
+		t.Errorf("clickable strategy must still carry both id and text, got: %s", strategies[0].Value)
+	}
+}

--- a/pkg/driver/uiautomator2/driver.go
+++ b/pkg/driver/uiautomator2/driver.go
@@ -1119,115 +1119,95 @@ func buildSelectorsForTap(sel flow.Selector, timeoutMs int) ([]LocatorStrategy, 
 }
 
 // buildSelectorsWithOptions builds selectors with optional clickable-first prioritization.
+//
+// A selector naming both an id and a text must match **one element that has
+// both**. Emitting id-only and text-only strategies as separate candidates made
+// them an OR, because the finder returns on the first strategy that hits
+// anything: the id matched, the text was never read, and a wrong text: passed
+// green against the right element. Same defect as the WDA one fixed in v1.1.25
+// (#130). UiSelector chains, so the two are combined into one query instead.
 func buildSelectorsWithOptions(sel flow.Selector, timeoutMs int, preferClickable bool) ([]LocatorStrategy, error) {
 	var strategies []LocatorStrategy
 	stateFilters := buildStateFilters(sel)
 
-	// ID-based selector — exact match FIRST, substring fallback ONLY if exact
-	// fails. The substring-only behaviour from before this change silently
-	// returned the wrong element when the exact id wasn't in the rendered
-	// tree (e.g. lazy ListView with the target offscreen): UiAutomator's
-	// regex `resourceIdMatches(".*X.*")` triggers internal scrolling, and if
-	// no resource-id ever matched the substring, the search could still
-	// return an unrelated element it happened to land on. Mirrors the web
-	// driver's cascade: exact → testid → substring → name → aria-label.
-	if sel.ID != "" {
-		escaped := escapeUIAutomatorString(sel.ID)
-		if preferClickable {
-			// Exact match — clickable first for tap commands.
-			strategies = append(strategies, LocatorStrategy{
-				Strategy: uiautomator2.StrategyUIAutomator,
-				Value:    `new UiSelector().resourceId("` + escaped + `").clickable(true)` + stateFilters,
-			})
+	// One tier is a set of equally-good queries; tiers are tried in order, and
+	// within a tier the clickable variants come first when a tap is being
+	// located. Preserved exactly as it was, so single-attribute selectors
+	// behave as before.
+	emit := func(tiers [][]string) {
+		for _, tier := range tiers {
+			if preferClickable {
+				for _, body := range tier {
+					strategies = append(strategies, LocatorStrategy{
+						Strategy: uiautomator2.StrategyUIAutomator,
+						Value:    `new UiSelector()` + body + `.clickable(true)` + stateFilters,
+					})
+				}
+			}
+			for _, body := range tier {
+				strategies = append(strategies, LocatorStrategy{
+					Strategy: uiautomator2.StrategyUIAutomator,
+					Value:    `new UiSelector()` + body + stateFilters,
+				})
+			}
 		}
-		// Exact match — any element.
-		strategies = append(strategies, LocatorStrategy{
-			Strategy: uiautomator2.StrategyUIAutomator,
-			Value:    `new UiSelector().resourceId("` + escaped + `")` + stateFilters,
-		})
-		if preferClickable {
-			// Substring fallback — clickable. Kept for backward compatibility
-			// with users relying on substring behaviour. Fires only after
-			// every exact-match strategy above failed.
-			strategies = append(strategies, LocatorStrategy{
-				Strategy: uiautomator2.StrategyUIAutomator,
-				Value:    `new UiSelector().resourceIdMatches(".*` + escaped + `.*").clickable(true)` + stateFilters,
-			})
-		}
-		// Substring fallback — any.
-		strategies = append(strategies, LocatorStrategy{
-			Strategy: uiautomator2.StrategyUIAutomator,
-			Value:    `new UiSelector().resourceIdMatches(".*` + escaped + `.*")` + stateFilters,
-		})
 	}
 
-	// Text-based selector - use textContains for literal text, textMatches for regex
+	// Exact id first, substring second. The substring fallback is kept for
+	// users relying on it, and fires only after every exact-match strategy:
+	// UiAutomator's `resourceIdMatches(".*X.*")` triggers internal scrolling
+	// and could return an unrelated element it happened to land on.
+	var idTiers [][]string
+	if sel.ID != "" {
+		escaped := escapeUIAutomatorString(sel.ID)
+		idTiers = [][]string{
+			{`.resourceId("` + escaped + `")`},
+			{`.resourceIdMatches(".*` + escaped + `.*")`},
+		}
+	}
+
+	// Text: regex patterns go through textMatches, literals through
+	// textContains with a case-insensitive fallback — Android dialog buttons
+	// display "CANCEL" while the hierarchy says "Cancel".
+	var textTiers [][]string
 	if sel.Text != "" {
 		if looksLikeRegex(sel.Text) {
-			// Use textMatches for regex patterns (case-insensitive)
 			pattern := "(?is)" + escapeUIAutomatorString(sel.Text)
-			if preferClickable {
-				strategies = append(strategies, LocatorStrategy{
-					Strategy: uiautomator2.StrategyUIAutomator,
-					Value:    `new UiSelector().textMatches("` + pattern + `").clickable(true)` + stateFilters,
-				})
-				strategies = append(strategies, LocatorStrategy{
-					Strategy: uiautomator2.StrategyUIAutomator,
-					Value:    `new UiSelector().descriptionMatches("` + pattern + `").clickable(true)` + stateFilters,
-				})
+			textTiers = [][]string{
+				{`.textMatches("` + pattern + `")`, `.descriptionMatches("` + pattern + `")`},
 			}
-			strategies = append(strategies, LocatorStrategy{
-				Strategy: uiautomator2.StrategyUIAutomator,
-				Value:    `new UiSelector().textMatches("` + pattern + `")` + stateFilters,
-			})
-			strategies = append(strategies, LocatorStrategy{
-				Strategy: uiautomator2.StrategyUIAutomator,
-				Value:    `new UiSelector().descriptionMatches("` + pattern + `")` + stateFilters,
-			})
 		} else {
-			// Literal text: try case-sensitive textContains first (preserves existing behavior),
-			// then fall back to case-insensitive textMatches for cases like Android dialog
-			// buttons where textAllCaps displays "CANCEL" but hierarchy text is "Cancel".
 			escaped := escapeUIAutomatorString(sel.Text)
 			ciPattern := `(?is).*\Q` + escaped + `\E.*`
-			if preferClickable {
-				strategies = append(strategies, LocatorStrategy{
-					Strategy: uiautomator2.StrategyUIAutomator,
-					Value:    `new UiSelector().textContains("` + escaped + `").clickable(true)` + stateFilters,
-				})
-				strategies = append(strategies, LocatorStrategy{
-					Strategy: uiautomator2.StrategyUIAutomator,
-					Value:    `new UiSelector().descriptionContains("` + escaped + `").clickable(true)` + stateFilters,
-				})
+			textTiers = [][]string{
+				{`.textContains("` + escaped + `")`, `.descriptionContains("` + escaped + `")`},
+				{`.textMatches("` + ciPattern + `")`, `.descriptionMatches("` + ciPattern + `")`},
 			}
-			strategies = append(strategies, LocatorStrategy{
-				Strategy: uiautomator2.StrategyUIAutomator,
-				Value:    `new UiSelector().textContains("` + escaped + `")` + stateFilters,
-			})
-			strategies = append(strategies, LocatorStrategy{
-				Strategy: uiautomator2.StrategyUIAutomator,
-				Value:    `new UiSelector().descriptionContains("` + escaped + `")` + stateFilters,
-			})
-			// Case-insensitive fallback
-			if preferClickable {
-				strategies = append(strategies, LocatorStrategy{
-					Strategy: uiautomator2.StrategyUIAutomator,
-					Value:    `new UiSelector().textMatches("` + ciPattern + `").clickable(true)` + stateFilters,
-				})
-				strategies = append(strategies, LocatorStrategy{
-					Strategy: uiautomator2.StrategyUIAutomator,
-					Value:    `new UiSelector().descriptionMatches("` + ciPattern + `").clickable(true)` + stateFilters,
-				})
-			}
-			strategies = append(strategies, LocatorStrategy{
-				Strategy: uiautomator2.StrategyUIAutomator,
-				Value:    `new UiSelector().textMatches("` + ciPattern + `")` + stateFilters,
-			})
-			strategies = append(strategies, LocatorStrategy{
-				Strategy: uiautomator2.StrategyUIAutomator,
-				Value:    `new UiSelector().descriptionMatches("` + ciPattern + `")` + stateFilters,
-			})
 		}
+	}
+
+	switch {
+	case len(idTiers) > 0 && len(textTiers) > 0:
+		// Both given: every query carries both, so nothing can match on one
+		// alone. Id tiers outer, so an exact id is preferred over a substring
+		// one whichever way the text matched.
+		var combined [][]string
+		for _, idTier := range idTiers {
+			for _, textTier := range textTiers {
+				var tier []string
+				for _, id := range idTier {
+					for _, text := range textTier {
+						tier = append(tier, id+text)
+					}
+				}
+				combined = append(combined, tier)
+			}
+		}
+		emit(combined)
+	case len(idTiers) > 0:
+		emit(idTiers)
+	case len(textTiers) > 0:
+		emit(textTiers)
 	}
 
 	// CSS selector for web views (no native wait support)

--- a/pkg/driver/uiautomator2/idtext_and_test.go
+++ b/pkg/driver/uiautomator2/idtext_and_test.go
@@ -1,0 +1,85 @@
+package uiautomator2
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/devicelab-dev/maestro-runner/pkg/flow"
+)
+
+// TestBuildSelectors_IDAndTextAreANDed is the correctness guarantee behind the
+// Android half of #130: a selector naming both an id and a text must match one
+// element carrying both.
+//
+// Before this, the builder emitted resourceId-only strategies and then
+// text-only ones as separate candidates, and tryFindElementFast returns on the
+// first that finds anything — so the id matched, the text was never read, and a
+// wrong text: passed green against the right element.
+func TestBuildSelectors_IDAndTextAreANDed(t *testing.T) {
+	strategies, err := buildSelectors(flow.Selector{ID: "boss.hp", Text: "7 misses"}, 5000)
+	if err != nil {
+		t.Fatalf("buildSelectors failed: %v", err)
+	}
+	if len(strategies) == 0 {
+		t.Fatal("expected at least one strategy")
+	}
+
+	for _, s := range strategies {
+		hasID := strings.Contains(s.Value, "resourceId")
+		hasText := strings.Contains(s.Value, "text") || strings.Contains(s.Value, "description")
+		if !hasID || !hasText {
+			t.Errorf("every strategy must constrain both id and text, got: %s", s.Value)
+		}
+	}
+}
+
+// The single-attribute paths are unchanged: given only one of the two, the
+// builder still emits the queries it always did.
+func TestBuildSelectors_SingleAttributeUnchanged(t *testing.T) {
+	idOnly, err := buildSelectors(flow.Selector{ID: "boss.hp"}, 5000)
+	if err != nil {
+		t.Fatalf("buildSelectors failed: %v", err)
+	}
+	// Exact resourceId, then the substring fallback.
+	if len(idOnly) != 2 {
+		t.Errorf("expected 2 id strategies, got %d", len(idOnly))
+	}
+	for _, s := range idOnly {
+		if strings.Contains(s.Value, "textContains") || strings.Contains(s.Value, "textMatches") {
+			t.Errorf("id-only selector must not constrain text, got: %s", s.Value)
+		}
+	}
+
+	textOnly, err := buildSelectors(flow.Selector{Text: "7 misses"}, 5000)
+	if err != nil {
+		t.Fatalf("buildSelectors failed: %v", err)
+	}
+	// textContains, descriptionContains, then the case-insensitive pair.
+	if len(textOnly) != 4 {
+		t.Errorf("expected 4 text strategies, got %d", len(textOnly))
+	}
+	for _, s := range textOnly {
+		if strings.Contains(s.Value, "resourceId") {
+			t.Errorf("text-only selector must not constrain id, got: %s", s.Value)
+		}
+	}
+}
+
+// A tap prefers a clickable element, and that preference has to survive the
+// combination rather than being dropped along with the separate strategies.
+func TestBuildSelectorsForTap_CombinedKeepsClickableFirst(t *testing.T) {
+	strategies, err := buildSelectorsForTap(flow.Selector{ID: "boss.hp", Text: "7 misses"}, 5000)
+	if err != nil {
+		t.Fatalf("buildSelectorsForTap failed: %v", err)
+	}
+	if len(strategies) == 0 {
+		t.Fatal("expected at least one strategy")
+	}
+	if !strings.Contains(strategies[0].Value, "clickable(true)") {
+		t.Errorf("expected a clickable-first strategy, got: %s", strategies[0].Value)
+	}
+	if !strings.Contains(strategies[0].Value, "resourceId") ||
+		!strings.Contains(strategies[0].Value, "textContains") {
+		t.Errorf("clickable strategy must still carry both id and text, got: %s", strategies[0].Value)
+	}
+}


### PR DESCRIPTION
Fixes #157

### The bug

On Android, a selector naming both an `id:` and a `text:` did not require them on the same element. `buildSelectorsWithOptions` appended `resourceId` strategies and then independent `text`/`description` strategies, and the finder returns on the first strategy that finds anything — so whenever the id matched, the text was never read.

The consequence is the dangerous direction: `assertVisible` with the right id and a wrong `text:` passed green, masking a wrong displayed value. The mirror case fails instead: with several elements sharing an id, `assertNotVisible` reported a match for an element that was not present.

Same defect fixed for iOS/WDA in v1.1.25 (#130) — "the WDA finder returned as soon as it found an element with the given id (never checking text)" — in the drivers that change did not cover. **Both Android builders had it**: `uiautomator2` and `devicelab`.

### The change

In both drivers the id and text constraints are built as *fragments*, and when both are given only their combination is emitted, so no query can match on one alone. `UiSelector` chains natively, so this is one query rather than a post-filter.

Ordering is preserved:

- exact `resourceId` before the `resourceIdMatches` substring fallback
- `textContains` before the case-insensitive `textMatches` fallback
- clickable-first variants for taps
- DeviceLab keeps its `hintContains` / `hintMatches` extensions and its extra regex tier

Selectors naming only an id, or only a text, emit exactly what they did before.

### One caveat, on DeviceLab

The Go side is correct for both drivers now, but for `--driver devicelab` **this is necessary and not sufficient**. Given the chained selector `new UiSelector().resourceId(X).textContains(Y)`, the on-device agent still resolves by `resourceId` alone and ignores the text predicate.

Measured on an Android emulator (API 36), with an id and a text that exist on *different* elements — this must fail:

```yaml
- assertVisible:
    id: "some.total"
    text: "BREAKFAST"     # exists on screen, on a different element
```

| driver | result |
|---|---|
| `uiautomator2` | fails — correct |
| `devicelab` | passes |

With both id and text absent, DeviceLab correctly fails, so it is specifically the chained predicate being dropped. That looks like an agent-side change I can't make from here — happy to file it separately if you'd prefer it tracked on its own.

### Tests

`pkg/driver/uiautomator2/idtext_and_test.go` and `pkg/driver/devicelab/idtext_and_test.go`, mirroring `pkg/driver/wda/idtext_and_test.go`:

- `TestBuildSelectors_IDAndTextAreANDed` — every emitted strategy constrains both. Fails against the previous code, printing the independent OR queries it produced.
- `TestBuildSelectors_SingleAttributeUnchanged` — id-only still emits the exact and substring queries, text-only the text queries. Passes before and after, which is what makes this a fix rather than a behaviour change.
- `TestBuildSelectorsForTap_CombinedKeepsClickableFirst` — the clickable preference survives the combination.

`go test ./pkg/driver/uiautomator2/... ./pkg/driver/devicelab/...` passes. On a device, `--driver uiautomator2` now behaves the same as the JVM CLI for all three cases.
