### PR TITLE
fix(ios): apply launch permissions on simulators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- The native iOS driver applies `launchApp` permissions after clearing app state, with specific permissions overriding `all` and failed permission updates stopping launch.
+
 ## [1.1.27] - 2026-09-11
 
 Mostly about **flows that already work on Maestro working the same way here**. One of 1.1.26's selector fixes woke up a parsing bug that had been dormant for months: any `inputText` that named an `id:` stopped finding its field, and because that step usually lives in a shared login sub-flow, whole suites went red on their first command. That is fixed, and so are three places where a Maestro flow was read differently here without a word — `speed:` on scrolls, the `value:` spelling of airplane and dark mode, and an element-relative `point:` on swipes. `addMedia` now takes documents, so a flow can seed a PDF and pick it in the system file picker, and a password passed through a variable no longer ends up in the report. There are no behaviour changes: nothing that passes on 1.1.26 should start failing.

--- a/pkg/driver/devicelab_ios/commands.go
+++ b/pkg/driver/devicelab_ios/commands.go
@@ -123,6 +123,18 @@ func (d *Driver) handleLaunchApp(s *flow.LaunchAppStep) *core.CommandResult {
 		}
 	}
 
+	if d.info != nil && d.info.IsSimulator {
+		permissions := s.Permissions
+		if len(permissions) == 0 {
+			permissions = map[string]string{"all": "allow"}
+		}
+		if res := d.handleSetPermissions(&flow.SetPermissionsStep{
+			AppID: bid, Permissions: permissions,
+		}); !res.Success {
+			return res
+		}
+	}
+
 	if s.StopApp != nil && *s.StopApp {
 		_ = exec.Command("xcrun", "simctl", "terminate", d.udid, bid).Run()
 	}

--- a/pkg/driver/devicelab_ios/launch_permissions_test.go
+++ b/pkg/driver/devicelab_ios/launch_permissions_test.go
@@ -1,0 +1,89 @@
+package devicelab_ios
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/devicelab-dev/maestro-runner/pkg/core"
+	"github.com/devicelab-dev/maestro-runner/pkg/flow"
+)
+
+func TestLaunchAppPermissions(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		permissions map[string]string
+		want        []string
+		fail        bool
+	}{
+		{"default", nil, []string{"grant all"}, false},
+		{"allow photos", map[string]string{"photos": "allow"}, []string{"grant photos"}, false},
+		{"deny photos", map[string]string{"photos": "deny"}, []string{"revoke photos"}, false},
+		{"reset photos", map[string]string{"photos": "unset"}, []string{"reset photos"}, false},
+		{"override all", map[string]string{"all": "allow", "photos": "deny"}, []string{"grant all", "revoke photos"}, false},
+		{"permission failure", map[string]string{"photos": "allow"}, []string{"grant photos"}, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			logPath := filepath.Join(dir, "simctl.log")
+			appPath := filepath.Join(dir, "Example.app")
+			if err := os.Mkdir(appPath, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			script := `#!/bin/sh
+printf '%s\n' "$*" >> "$TEST_SIMCTL_LOG"
+case "$2" in
+  get_app_container) printf '%s\n' "$TEST_APP_PATH" ;;
+  privacy)
+    if [ "$TEST_PERMISSION_FAILURE" = 1 ]; then
+      printf 'permission update failed\n' >&2
+      exit 1
+    fi
+    ;;
+esac
+`
+			if err := os.WriteFile(filepath.Join(dir, "xcrun"), []byte(script), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+			t.Setenv("TEST_SIMCTL_LOG", logPath)
+			t.Setenv("TEST_APP_PATH", appPath)
+			if tc.fail {
+				t.Setenv("TEST_PERMISSION_FAILURE", "1")
+			}
+			driver := NewDriver(nil, &core.PlatformInfo{IsSimulator: true}, "test-device", nil)
+			driver.SetAppID("com.example.app")
+			result := driver.handleLaunchApp(&flow.LaunchAppStep{
+				ClearState: true, Permissions: tc.permissions,
+			})
+			if result.Success == tc.fail {
+				t.Errorf("success = %v: %s", result.Success, result.Message)
+			}
+			data, err := os.ReadFile(logPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			calls := string(data)
+			previous := strings.Index(calls, "simctl install test-device ")
+			if previous < 0 {
+				t.Fatal("expected clearState to reinstall the app")
+			}
+			for _, action := range tc.want {
+				call := "simctl privacy test-device " + action + " com.example.app\n"
+				position := strings.Index(calls, call)
+				if position <= previous {
+					t.Errorf("expected %q after app installation and earlier permission updates; calls:\n%s", call, calls)
+				}
+				previous = position
+			}
+			launch := strings.Index(calls, "simctl launch ")
+			if tc.fail && launch >= 0 {
+				t.Error("app launched after a permission update failed")
+			}
+			if !tc.fail && launch <= previous {
+				t.Error("permissions must be applied before launch")
+			}
+		})
+	}
+}

--- a/pkg/driver/devicelab_ios/permissions.go
+++ b/pkg/driver/devicelab_ios/permissions.go
@@ -3,6 +3,7 @@ package devicelab_ios
 import (
 	"fmt"
 	"os/exec"
+	"sort"
 	"strings"
 
 	"github.com/devicelab-dev/maestro-runner/pkg/core"
@@ -38,7 +39,18 @@ func (d *Driver) handleSetPermissions(step *flow.SetPermissionsStep) *core.Comma
 
 	var applied int
 	var failures []string
-	for name, value := range step.Permissions {
+	names := make([]string, 0, len(step.Permissions))
+	for name := range step.Permissions {
+		if name != "all" {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	if _, ok := step.Permissions["all"]; ok {
+		names = append([]string{"all"}, names...)
+	}
+	for _, name := range names {
+		value := step.Permissions[name]
 		services := core.IOSPrivacyServices(name)
 		if len(services) == 0 {
 			// iOS exposes no host-side control over this one. Saying so is


### PR DESCRIPTION
Apply `launchApp` permissions after clearing simulator app state, with `all: allow` by default and specific overrides honoured (related: #147).

Validated with regression tests, the driver race suite and iOS picker/negative checks; full checks remain blocked by existing lint/cancellation failures and a browser startup timeout.
